### PR TITLE
Clean up, finalize Deezer data generation

### DIFF
--- a/notebooks/Deezer Dataset Loader.ipynb
+++ b/notebooks/Deezer Dataset Loader.ipynb
@@ -20,8 +20,8 @@
     "\n",
     "Each user is presented with `len_list=12` randomly selected items, and the $p(u,i)$ is calculated for each item. Then each probability is turned into a 0/1 reward outcome by simulating a Bernoulli random variable with $p=p(u,i)$. The rewards are tabulated using Deezer's cascading reward system:\n",
     "- If the user clicks none of the 12 items, we record the system as receiving 0 reward for each of the `len_init=3` items in the list, because we assume they only saw the first 3 items.\n",
-    "- If the user clicks items $i_1,\\dots,i_j$, where $i_j$ is furthest down the list, we record the 0/1 rewards for the first $\\max(l_{init}, i_j)$ items. \n",
-    "- (Optionally, we can choose to ignore the cascade rule and always record all 0/1 rewards.)\n",
+    "- If the user clicks items $i_1,\\dots,i_j$, where $i_1$ is earliest and $i_j$ is latest the list, we record the 0/1 rewards for the first $\\max(l_{\\textrm{init}},i_j)$ items. **NOTE**: Deezer's code actually records the first $i_j$ rewards even if $i_j<l_{\\textrm{init}}$. We checked with Deezer and they acknowledged the simplification, noting it doesn't affect the results appreciably. We chose to follow the description in the paper.\n",
+    "- (Optionally, we can choose to ignore the cascade rule and always record all `len_list` 0/1 rewards.)\n",
     "\n",
     "The relevant section from the paper is excerpted below:\n",
     "\n",
@@ -85,13 +85,17 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Calculating user scores:: 100%|██████████| 1500/1500 [00:00<00:00, 5861.67it/s]\n",
-      "Generating feedback:: 100%|██████████| 1500/1500 [00:00<00:00, 46733.54it/s]\n"
+      "Calculating user scores:: 100%|██████████| 1000/1000 [00:00<00:00, 4673.18it/s]\n",
+      "Generating feedback:: 100%|██████████| 1000/1000 [00:00<00:00, 161549.28it/s]\n"
      ]
     }
    ],
    "source": [
-    "feedback_deezer_cascade = deezer_data.obtain_batch_bandit_feedback(n_batches=3, users_per_batch=500, cascade=True)"
+    "feedback_deezer_cascade = deezer_data.obtain_batch_bandit_feedback(\n",
+    "    n_batches=2,\n",
+    "    users_per_batch=500,\n",
+    "    cascade=True, seed=1\n",
+    ")"
    ]
   },
   {
@@ -103,29 +107,29 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "cascade is enabled, so we see between 3 and 12 items per user per turn\n",
-      "minimum number of actions is thus 3*500*3=4500\n",
+      "Cascade is enabled, so we see between 3 and 12 items per user per turn\n",
+      "minimum number of actions is thus 2 batches * 500 users * 3 items = 3000\n",
       "feedback dict:\n",
-      "  action: <class 'numpy.ndarray'>, (4976,)\n",
-      "  reward: <class 'numpy.ndarray'>, (4976,)\n",
-      "  position: <class 'numpy.ndarray'>, (4976,)\n",
-      "  context: <class 'numpy.ndarray'>, (4976, 97)\n",
-      "  action_context: <class 'numpy.ndarray'>, (4976, 97)\n",
-      "  pscore: <class 'numpy.ndarray'>, (4976,)\n",
-      "  n_rounds: <class 'int'>\n",
-      "  n_actions: <class 'int'>\n"
+      "  action: <class 'numpy.ndarray'>, (3354,)\n",
+      "  reward: <class 'numpy.ndarray'>, (3354,)\n",
+      "  position: <class 'numpy.ndarray'>, (3354,)\n",
+      "  context: <class 'numpy.ndarray'>, (3354, 97)\n",
+      "  action_context: <class 'numpy.ndarray'>, (3354, 97)\n",
+      "  pscore: <class 'numpy.ndarray'>, (3354,)\n",
+      "  n_rounds: 3354\n",
+      "  n_actions: 862\n"
      ]
     }
    ],
    "source": [
-    "print(\"cascade is enabled, so we see between 3 and 12 items per user per turn\")\n",
-    "print(\"minimum number of actions is thus 3*500*3=4500\")\n",
+    "print(\"Cascade is enabled, so we see between 3 and 12 items per user per turn\")\n",
+    "print(\"minimum number of actions is thus 2 batches * 500 users * 3 items = 3000\")\n",
     "print(\"feedback dict:\")\n",
     "for key, value in feedback_deezer_cascade.items():\n",
     "    if key[0:2] != \"n_\":\n",
     "        print(f\"  {key}: {type(value)}, {value.shape}\")\n",
     "    else:\n",
-    "        print(f\"  {key}: {type(value)}\")"
+    "        print(f\"  {key}: {value}\")"
    ]
   },
   {
@@ -137,14 +141,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Calculating user scores:: 100%|██████████| 1500/1500 [00:00<00:00, 6181.26it/s]\n",
-      "Generating feedback:: 100%|██████████| 1500/1500 [00:00<00:00, 53544.31it/s]\n"
+      "Calculating user scores:: 100%|██████████| 1000/1000 [00:00<00:00, 6111.76it/s]\n",
+      "Generating feedback:: 100%|██████████| 1000/1000 [00:00<00:00, 60200.71it/s]\n"
      ]
     }
    ],
    "source": [
     "feedback_deezer_no_cascade = deezer_data.obtain_batch_bandit_feedback(\n",
-    "    n_batches=3,\n",
+    "    n_batches=2,\n",
     "    users_per_batch=500,\n",
     "    cascade=False\n",
     ")"
@@ -160,28 +164,28 @@
      "output_type": "stream",
      "text": [
       "cascade is disabled, so we ways see 12 items per user per turn\n",
-      "number of actions is thus 3*500*12=18,000\n",
+      "number of actions is thus 2 batches * 500 users * 12 items = 12,000\n",
       "feedback dict:\n",
-      "  action: <class 'numpy.ndarray'>, (18000,)\n",
-      "  reward: <class 'numpy.ndarray'>, (18000,)\n",
-      "  position: <class 'numpy.ndarray'>, (18000,)\n",
-      "  context: <class 'numpy.ndarray'>, (18000, 97)\n",
-      "  action_context: <class 'numpy.ndarray'>, (18000, 97)\n",
-      "  pscore: <class 'numpy.ndarray'>, (18000,)\n",
-      "  n_rounds: <class 'int'>\n",
-      "  n_actions: <class 'int'>\n"
+      "  action: <class 'numpy.ndarray'>, (12000,)\n",
+      "  reward: <class 'numpy.ndarray'>, (12000,)\n",
+      "  position: <class 'numpy.ndarray'>, (12000,)\n",
+      "  context: <class 'numpy.ndarray'>, (12000, 97)\n",
+      "  action_context: <class 'numpy.ndarray'>, (12000, 97)\n",
+      "  pscore: <class 'numpy.ndarray'>, (12000,)\n",
+      "  n_rounds: 12000\n",
+      "  n_actions: 862\n"
      ]
     }
    ],
    "source": [
     "print(\"cascade is disabled, so we ways see 12 items per user per turn\")\n",
-    "print(\"number of actions is thus 3*500*12=18,000\")\n",
+    "print(\"number of actions is thus 2 batches * 500 users * 12 items = 12,000\")\n",
     "print(\"feedback dict:\")\n",
     "for key, value in feedback_deezer_no_cascade.items():\n",
     "    if key[0:2] != \"n_\":\n",
     "        print(f\"  {key}: {type(value)}, {value.shape}\")\n",
     "    else:\n",
-    "        print(f\"  {key}: {type(value)}\")"
+    "        print(f\"  {key}: {value}\")"
    ]
   }
  ],

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,7 +38,7 @@ nbformat==5.0.8
 nest-asyncio==1.4.2
 notebook==6.1.5
 numpy==1.19.3
-obp==0.3.1
+obp==0.3.3
 packaging==20.4
 pandas==1.1.4
 pandocfilters==1.4.3


### PR DESCRIPTION
Finalized and cleaned up the logic for generating Deezer data. After speaking with Guillaume from Deezer, I decided to side with the paper's logic: in cascade mode, if the last click index is less than `len_init`, still observe the first `len_init` rewards.

I also added docstrings and reran the notebook.

Correspondence w/ Guillaume included below for posterity:

> Hi Guillaume,
> 
> I'm a master's student at NYU, and for a class on recommender systems, my group and I are running some experiments on the Deezer carousel dataset using the Open Bandit Pipeline. I had a question about your experiments and wanted to make sure I understand correctly the proper implementation.
> 
> In the paper, you write:
> - An active user who did not stream any card during the round only saw the L_init first ones.
> - An active user who streamed the ith card, with i in [1, ..., L], saw all cards from ranks 1 to max(L_init, i).
> In particular, you note that if the user clicked only the second playlist, we would record 0 1 0 X X X...
> 
> However, if I'm reading the code right, it appears that in your policies, you have this logic:
> if self.cascade_model and ((total_stream == 0 and nb_display == l_init) or (r == 1))
> The "or (r ==1)" part seems to suggest that if the user clicked a playlist, we immediately finish observing rewards for this user, even if we have not reached L_init playlists yet. In other words, instead of recording 0 1 0 X X X, we would record 0 1 X X X X. 
> 
> I wanted to check with you which description is correct: is the desired behavior to stop at the first observed click, even if we haven't yet seen the first L_init playlists? Or should we always observe rewards for the first 3?

> Dear Dan,
> 
> First of all, thank you very much for your message and for your interest in our work!
> 
> You are right. In the final version of the code, that we publicly released on GitHub, we indeed made a few simplifications w.r.t. the original experiments from the RecSys paper. One of these simplifications is that, as mentioned in the policies.py file:
> "If a user clicked and streamed a playlist at rank r, he/she stops browsing and all playlists from ranks r+1 to n_recos are considered as "unseen" and corresponding arms are not updated."
> 
> Overall, it simplifies the code's readability, which was our main objective, but I agree that it also creates an inconsistency with the example b) from the paper. I will check this point with our team at Deezer and, when time permits, we will either:
> - add the missing condition to exactly match the example b) from the paper (i.e. 0 1 0 X X X instead of 0 1 X X X X) ; 
> - keep the same code, but add a comment to more explicitly warn future users about this slight change.
> 
> Regarding the experiments, this slight simplification does not impact the final results. We achieved very similar regret curves with and without it. 
> So, I'd say that, If you want to be rigorous, you can re-implement the actual behaviour from the paper*, which is the "desired behavior". But, if you prefer to keep it simple, then using the current simplified code will be fine especially for a course project.
> 
> * i.e. add an additional condition checking, when total_stream > 0, whether the first streamed card has a rank r strictly lower than l_init. Then, if it is the case, you negatively update all cards from r+1 to l_init.
> 
> Best regards,