### PR TITLE
Support online and offline log-generation for Deezer

### DIFF
--- a/notebooks/Deezer Dataset - Offline and Online Learning.ipynb
+++ b/notebooks/Deezer Dataset - Offline and Online Learning.ipynb
@@ -1,0 +1,502 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "\n",
+    "from obp.ope import ReplayMethod\n",
+    "from obp.policy import EpsilonGreedy\n",
+    "from obp.simulator import run_bandit_simulation\n",
+    "from obp.utils import convert_to_action_dist\n",
+    "\n",
+    "from sd_bandits.obp_extensions.dataset import DeezerDataset"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Working with Deezer Data\n",
+    "\n",
+    "Deezer's data is unlike ZOZO's because it's not logged feedback—instead it's a pretrained logistic regression model we can use to calculate user-item click probabilities. \n",
+    "\n",
+    "The `DeezerDataset` object lets us load the user and playlist features so that we can use it to get the data we want."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "user_features_path = \"../data/deezer_carousel_bandits/user_features.csv\"\n",
+    "playlist_features_path = \"../data/deezer_carousel_bandits/playlist_features.csv\"\n",
+    "\n",
+    "deezer_data = DeezerDataset(\n",
+    "    user_features_path,\n",
+    "    playlist_features_path,\n",
+    "    len_list=12,\n",
+    "    len_init=3,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "From here we have three options on what we can do next:\n",
+    "\n",
+    "1. Simulate logs from a uniformly random policy, then do off-policy training and evaluation of a new policy using `ReplayMethod`.\n",
+    "2. Simulate logs from any policy we want, then just read out the rewards (using `ReplayMethod` or equivalently `rewards.mean()`).\n",
+    "3. Simulate logs from a uniformly random policy, then do off-policy training and evaluation using regression-based estimators, where the regression model is simply Deezer's logistic regression.\n",
+    "\n",
+    "I would argue that #3 is an unnecessarily complicated version of #2. I think #3 makes sense in ZOZO's case, where you have logged data and you're training a regression, but in our case where we have a regression and we're generating \"logged data,\" it feels a bit bizarre and I think we should skip it. \n",
+    "\n",
+    "In this notebook, I'm only going to demonstrate #1 and #2.\n",
+    "\n",
+    "## 1. Make random logs and perform off-policy learning & estimation\n",
+    "\n",
+    "### Make random logs \n",
+    "\n",
+    "The first method is to use the data Deezer gives us to create data that looks like ZOZO's logs. We do this following a procedure similar to Deezer's simulation procedure:\n",
+    "1. Select `n_batches` of `users_per_batch` random users (with replacement).\n",
+    "2. For each users, select items uniformly at random.\n",
+    "3. Observe the rewards by calculating user-item click probabilities with Deezer's logistic features.\n",
+    "4. Optionally simulate Deezer's cascade observation model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Calculating click probabilities: 100%|██████████| 100000/100000 [00:16<00:00, 6048.32it/s]\n",
+      "Generating feedback: 100%|██████████| 100000/100000 [00:00<00:00, 129875.72it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "cascade is enabled, so we observe at least 3 items per user per user session\n",
+      "min number of actions is thus 100 batches * 1000 users * 3 items = 300,000\n",
+      "feedback dict:\n",
+      "  action: <class 'numpy.ndarray'>, (333027,)\n",
+      "  reward: <class 'numpy.ndarray'>, (333027,)\n",
+      "  position: <class 'numpy.ndarray'>, (333027,)\n",
+      "  context: <class 'numpy.ndarray'>, (333027, 97)\n",
+      "  action_context: <class 'numpy.ndarray'>, (333027, 97)\n",
+      "  pscore: <class 'numpy.ndarray'>, (333027,)\n",
+      "  n_rounds: 333027\n",
+      "  n_actions: 862\n",
+      "  users: <class 'numpy.ndarray'>, (100000,)\n"
+     ]
+    }
+   ],
+   "source": [
+    "random_deezer_feedback = deezer_data.obtain_batch_bandit_feedback(\n",
+    "    n_batches=100,\n",
+    "    users_per_batch=1000,\n",
+    "    cascade=True,\n",
+    "    seed=1,\n",
+    ")\n",
+    "\n",
+    "print(\"\\ncascade is enabled, so we observe at least 3 items per user per user session\")\n",
+    "print(\"min number of actions is thus 100 batches * 1000 users * 3 items = 300,000\")\n",
+    "print(\"feedback dict:\")\n",
+    "for key, value in random_deezer_feedback.items():\n",
+    "    if key[0:2] != \"n_\":\n",
+    "        print(f\"  {key}: {type(value)}, {value.shape}\")\n",
+    "    else:\n",
+    "        print(f\"  {key}: {value}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "What's the expected reward of the uniformly random policy?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Expected reward for uniform random actions: 0.027\n"
+     ]
+    }
+   ],
+   "source": [
+    "exp_rand_reward = round(random_deezer_feedback[\"reward\"].mean(),4)\n",
+    "print(f\"Expected reward for uniform random actions: {exp_rand_reward}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Off policy-learning\n",
+    "\n",
+    "Now if we want to know how epsilon-greedy bandits perform, we have to use the simulator to do off-policy learning. \n",
+    "\n",
+    "This means we run through our new simulated uniformly-random item logs and we can only update our epsilon-greedy bandit and observe a reward if the action it presents matches what was presented in our random dataset.\n",
+    "\n",
+    "Unfortunately, matches are very rare! Especially when there are 12 positions and 800+ playlists. We're going to set our bandit's `batch_size=1` just to guarantee we update our bandit params as many times as we can."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 333027/333027 [00:14<00:00, 22511.74it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "The epilon-greedy bandit's actions matched on only 350 rounds, out of a possible 333027 :(\n"
+     ]
+    }
+   ],
+   "source": [
+    "e_greedy_simulated_log = EpsilonGreedy(\n",
+    "    n_actions=deezer_data.n_actions,\n",
+    "    len_list=12,\n",
+    "    batch_size=1,\n",
+    "    random_state=1,\n",
+    "    epsilon=0.2,\n",
+    ")\n",
+    "\n",
+    "action_dist_from_simulated_log = run_bandit_simulation(random_deezer_feedback, e_greedy_simulated_log)\n",
+    "\n",
+    "number_of_matches = e_greedy_simulated_log.n_trial\n",
+    "number_of_rounds = random_deezer_feedback[\"n_rounds\"]\n",
+    "print(f\"\\nThe epilon-greedy bandit's actions matched on only {number_of_matches} rounds, out of a possible {number_of_rounds} :(\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Off-policy evaluation\n",
+    "\n",
+    "So how well did our off-policy-trained epsilon-greedy bandit do? We don't expect it to do particularly well since it could only update on a handful of matched examples. Furthermore, we expect high variance estimates considering that there are so few data points to work with."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Expected reward for epsilon-greedy bandit trained on random logs: 0.0148 (or 0.55x random baseline)\n",
+      "95% confidence interval is 0.0029-0.0286, a super big range!\n"
+     ]
+    }
+   ],
+   "source": [
+    "replay_estimator = ReplayMethod()\n",
+    "\n",
+    "off_policy_eval = replay_estimator.estimate_interval(\n",
+    "    reward=random_deezer_feedback[\"reward\"],\n",
+    "    action=random_deezer_feedback[\"action\"],\n",
+    "    position=random_deezer_feedback[\"position\"],\n",
+    "    action_dist=action_dist_from_simulated_log,\n",
+    "    random_state=1\n",
+    ")\n",
+    "\n",
+    "mean_eps_greedy_log_reward = np.round(off_policy_eval[\"mean\"], 4)\n",
+    "eps_greedy_log_relative = np.round(off_policy_eval[\"mean\"] / random_deezer_feedback[\"reward\"].mean(), 2)\n",
+    "\n",
+    "print(f\"Expected reward for epsilon-greedy bandit trained on random logs: {mean_eps_greedy_log_reward}\",\n",
+    "      f\"(or {eps_greedy_log_relative}x random baseline)\")\n",
+    "\n",
+    "lo_eps_greedy_log_reward = np.round(off_policy_eval[\"95.0% CI (lower)\"], 4)\n",
+    "hi_eps_greedy_log_reward = np.round(off_policy_eval[\"95.0% CI (upper)\"], 4)\n",
+    "print(f\"95% confidence interval is {lo_eps_greedy_log_reward}-{hi_eps_greedy_log_reward}, a super big range!\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As we can see, the model trained this way probably did _worse_ than random, and had a huge confidence interval.\n",
+    "\n",
+    "Surely there's a better way!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Do _online_ bandit learning\n",
+    "\n",
+    "Since we can calculate the probability for every possible user-item combo, there's no need to rely on a fake log, we can just use the model. \n",
+    "\n",
+    "This time, we'll supply the `policy` argument to `obtain_batch_bandit_feedback`: now instead of uniformly random actions chosen for each user, we'll get actions chosen by the supplied bandit policy. \n",
+    "\n",
+    "Furthermore, the policy will update once per batch of randomly selected _users_ to better simulate Deezer's experiment."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Simulating online learning: 100%|██████████| 100000/100000 [00:14<00:00, 6689.06it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "cascade is enabled, so we observe at least 3 items per user per user session\n",
+      "min number of actions is thus 10 batches * 100000 users * 3 items = 300,000\n",
+      "feedback dict:\n",
+      "  action: <class 'numpy.ndarray'>, (403200,)\n",
+      "  reward: <class 'numpy.ndarray'>, (403200,)\n",
+      "  position: <class 'numpy.ndarray'>, (403200,)\n",
+      "  context: <class 'numpy.ndarray'>, (403200, 97)\n",
+      "  action_context: <class 'numpy.ndarray'>, (403200, 97)\n",
+      "  pscore: None\n",
+      "  n_rounds: 403200\n",
+      "  n_actions: 862\n",
+      "  policy: EpsilonGreedy(n_actions=862, len_list=12, batch_size=403200, random_state=1, epsilon=0.2, policy_name='egreedy_1.0')\n",
+      "  selected_actions: <class 'numpy.ndarray'>, (403200, 12)\n",
+      "  users: <class 'numpy.ndarray'>, (100000,)\n"
+     ]
+    }
+   ],
+   "source": [
+    "e_greedy = EpsilonGreedy(\n",
+    "    n_actions=deezer_data.n_actions,\n",
+    "    len_list=12,\n",
+    "    # this batch_size setting will be ignored because supplying the policy\n",
+    "    # to `deezer_data.obtain_batch_bandit_feedback` will manually update\n",
+    "    # once per batch of *users*\n",
+    "    batch_size=1, \n",
+    "    random_state=1,\n",
+    "    epsilon=0.2,\n",
+    ")\n",
+    "\n",
+    "eg_deezer_feedback = deezer_data.obtain_batch_bandit_feedback(\n",
+    "    policy=e_greedy,\n",
+    "    n_batches=100, # this is how many times our bandit will have its params updated\n",
+    "    users_per_batch=1000,\n",
+    "    cascade=True,\n",
+    "    seed=1\n",
+    ")\n",
+    "\n",
+    "print(\"\\ncascade is enabled, so we observe at least 3 items per user per user session\")\n",
+    "print(\"min number of actions is thus 10 batches * 100000 users * 3 items = 300,000\")\n",
+    "print(\"feedback dict:\")\n",
+    "for key, value in eg_deezer_feedback.items():\n",
+    "    if key[0:2] != \"n_\" and key != \"policy\" and value is not None:\n",
+    "        print(f\"  {key}: {type(value)}, {value.shape}\")\n",
+    "    else:\n",
+    "        print(f\"  {key}: {value}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we've generated a dataset that contains the actions and rewards generated by an online experiment with our epsilon-greedy bandit.\n",
+    "\n",
+    "Using the `ReplayMethod` here isn't strictly necessary: since we did online learning, our logs always match our actions and so we could just as easily get `mean_eps_greedy_online_reward = eg_deezer_feedback[\"reward\"].mean()`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Expected reward for epsilon-greedy bandit trained online: 0.0602 (2.22x random baseline)!\n",
+      "95% confidence interval is 0.0594-0.0609, a much smaller range!\n"
+     ]
+    }
+   ],
+   "source": [
+    "replay_estimator = ReplayMethod()\n",
+    "\n",
+    "eps_greedy_estimates = replay_estimator.estimate_interval(\n",
+    "    reward=eg_deezer_feedback[\"reward\"],\n",
+    "    action=eg_deezer_feedback[\"action\"],\n",
+    "    position=eg_deezer_feedback[\"position\"],\n",
+    "    action_dist=convert_to_action_dist(deezer_data.n_actions, eg_deezer_feedback[\"selected_actions\"]))\n",
+    "\n",
+    "mean_eps_greedy_online_reward = np.round(eps_greedy_estimates[\"mean\"], 4)\n",
+    "eps_greedy_online_relative = np.round(eps_greedy_estimates[\"mean\"] / random_deezer_feedback[\"reward\"].mean(), 2)\n",
+    "\n",
+    "print(f\"Expected reward for epsilon-greedy bandit trained online: {mean_eps_greedy_online_reward}\",\n",
+    "      f\"({eps_greedy_online_relative}x random baseline)!\")\n",
+    "\n",
+    "lo_eps_greedy_online_reward = np.round(eps_greedy_estimates[\"95.0% CI (lower)\"], 4)\n",
+    "hi_eps_greedy_online_reward = np.round(eps_greedy_estimates[\"95.0% CI (upper)\"], 4)\n",
+    "print(f\"95% confidence interval is {lo_eps_greedy_online_reward}-{hi_eps_greedy_online_reward}, a much smaller range!\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Wow, much much better!\n",
+    "\n",
+    "Note that we can get _even better_ performance by updating our parameters more often. \n",
+    "\n",
+    "We'll switch from `n_batches=100`, `users_per_batch=1000` to `n_batches=100000`, `user_per_batch=1` so we'll update 100000 times instead of 100 times."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Simulating online learning: 100%|██████████| 100000/100000 [00:16<00:00, 6230.29it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Expected reward for epsilon-greedy bandit trained online and updated every round: 0.073\n"
+     ]
+    }
+   ],
+   "source": [
+    "e_greedy = EpsilonGreedy(\n",
+    "    n_actions=deezer_data.n_actions,\n",
+    "    len_list=12,\n",
+    "    batch_size=1, # this will be ignored\n",
+    "    random_state=1,\n",
+    "    epsilon=0.2,\n",
+    ")\n",
+    "\n",
+    "eg_deezer_feedback_2 = deezer_data.obtain_batch_bandit_feedback(\n",
+    "    policy=e_greedy,\n",
+    "    n_batches=100000,\n",
+    "    users_per_batch=1,\n",
+    "    cascade=True,\n",
+    "    seed=1\n",
+    ")\n",
+    "\n",
+    "mean_eps_greedy_online_reward_2 = np.round(eg_deezer_feedback_2['reward'].mean(),4)\n",
+    "print(f\"Expected reward for epsilon-greedy bandit trained online and updated every round: {mean_eps_greedy_online_reward_2}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "An improvement!\n",
+    "\n",
+    "And by the way, if you're worried that we sampled different users, don't be: The same list of users will be generated because a) we used he same seed and b) the call to generate users is \n",
+    "```python\n",
+    "        user_indices = rng.choice(\n",
+    "            range(len(self.user_features)),\n",
+    "            size=users_per_batch * n_batches,\n",
+    "            replace=True,\n",
+    "        )\n",
+    "```\n",
+    "and `1 * 100000` is equal to `1000 * 100`.\n",
+    "\n",
+    "Don't believe me?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "all(eg_deezer_feedback_2[\"users\"] == eg_deezer_feedback[\"users\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Final proposal\n",
+    "\n",
+    "Since the Deezer dataset has so many positions and playlists, the likelihood of \"matches\" on randomly-generated logs is extremely low, and all bandits will perform terribly. I propose we instead do these \"online bandit learning\" experiments (the #2 method) and just use the `ReplayMethod` to calculate our confidence interval of expected reward."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/notebooks/Deezer Dataset Loader.ipynb
+++ b/notebooks/Deezer Dataset Loader.ipynb
@@ -42,7 +42,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -59,7 +59,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -78,15 +78,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Calculating user scores:: 100%|██████████| 1000/1000 [00:00<00:00, 4673.18it/s]\n",
-      "Generating feedback:: 100%|██████████| 1000/1000 [00:00<00:00, 161549.28it/s]\n"
+      "Calculating user scores:: 100%|██████████| 1000/1000 [00:00<00:00, 5434.37it/s]\n",
+      "Generating feedback:: 100%|██████████| 1000/1000 [00:00<00:00, 135243.41it/s]\n"
      ]
     }
    ],
@@ -100,7 +100,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -117,7 +117,8 @@
       "  action_context: <class 'numpy.ndarray'>, (3354, 97)\n",
       "  pscore: <class 'numpy.ndarray'>, (3354,)\n",
       "  n_rounds: 3354\n",
-      "  n_actions: 862\n"
+      "  n_actions: 862\n",
+      "  all_item_indices: <class 'numpy.ndarray'>, (1000, 12)\n"
      ]
     }
    ],
@@ -134,15 +135,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Calculating user scores:: 100%|██████████| 1000/1000 [00:00<00:00, 6111.76it/s]\n",
-      "Generating feedback:: 100%|██████████| 1000/1000 [00:00<00:00, 60200.71it/s]\n"
+      "Calculating user scores:: 100%|██████████| 1000/1000 [00:00<00:00, 6133.92it/s]\n",
+      "Generating feedback:: 100%|██████████| 1000/1000 [00:00<00:00, 58823.67it/s]\n"
      ]
     }
    ],
@@ -156,7 +157,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -173,12 +174,13 @@
       "  action_context: <class 'numpy.ndarray'>, (12000, 97)\n",
       "  pscore: <class 'numpy.ndarray'>, (12000,)\n",
       "  n_rounds: 12000\n",
-      "  n_actions: 862\n"
+      "  n_actions: 862\n",
+      "  all_item_indices: <class 'numpy.ndarray'>, (1000, 12)\n"
      ]
     }
    ],
    "source": [
-    "print(\"cascade is disabled, so we ways see 12 items per user per turn\")\n",
+    "print(\"cascade is disabled, so we always see 12 items per user per turn\")\n",
     "print(\"number of actions is thus 2 batches * 500 users * 12 items = 12,000\")\n",
     "print(\"feedback dict:\")\n",
     "for key, value in feedback_deezer_no_cascade.items():\n",
@@ -187,6 +189,13 @@
     "    else:\n",
     "        print(f\"  {key}: {value}\")"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
I think this PR is best explained by [this notebook](https://github.com/daturkel/sd_bandits/blob/f205c5fff4de9a7c0e941fd5df277f0ed6a8038f/notebooks/Deezer%20Dataset%20-%20Offline%20and%20Online%20Learning.ipynb). 

Basically, generating uniformly random logs from the Deezer dataset is always going to lead to terrible-performing bandits because the probability of a match with 12 positions and 850+ playlists is miniscule.

But we don't have to do that: we can instead generate logs while learning a bandit _online_: just see which actions the bandit selects, calculate the click probabilities, and update the bandits at desired intervals.

This PR creates the option to do this new online method of log generation. This also means there's no need to use off-policy estimators for the Deezer data: we can always just take the average reward of an on-policy training session. (I think this makes way more sense than trying to use the complicated estimators by feeding them the same logistic model used to create random logs...)