### PR TITLE
Slurm scripts

### DIFF
--- a/conda_envs/sd_bandits.yml
+++ b/conda_envs/sd_bandits.yml
@@ -1,0 +1,65 @@
+name: sd_bandits_env
+channels:
+  - defaults
+dependencies:
+  - _libgcc_mutex=0.1=main
+  - backcall=0.2.0=py_0
+  - ca-certificates=2020.10.14=0
+  - certifi=2020.6.20=pyhd3eb1b0_3
+  - decorator=4.4.2=py_0
+  - ipykernel=5.3.4=py38h5ca1d4c_0
+  - ipython=7.19.0=py38hb070fc8_0
+  - ipython_genutils=0.2.0=py38_0
+  - jedi=0.17.2=py38_0
+  - jupyter_client=6.1.7=py_0
+  - jupyter_core=4.6.3=py38_0
+  - ld_impl_linux-64=2.33.1=h53a641e_7
+  - libedit=3.1.20191231=h14c3975_1
+  - libffi=3.2.1=hf484d3e_1007
+  - libgcc-ng=9.1.0=hdf63c60_0
+  - libsodium=1.0.18=h7b6447c_0
+  - libstdcxx-ng=9.1.0=hdf63c60_0
+  - ncurses=6.2=he6710b0_1
+  - openssl=1.1.1h=h7b6447c_0
+  - parso=0.7.0=py_0
+  - pexpect=4.8.0=pyhd3eb1b0_3
+  - pickleshare=0.7.5=py38_1000
+  - pip=20.2.4=py38h06a4308_0
+  - prompt-toolkit=3.0.8=py_0
+  - ptyprocess=0.6.0=pyhd3eb1b0_2
+  - pygments=2.7.2=pyhd3eb1b0_0
+  - python=3.8.0=h0371630_2
+  - python-dateutil=2.8.1=py_0
+  - pyzmq=19.0.2=py38he6710b0_1
+  - readline=7.0=h7b6447c_5
+  - setuptools=50.3.1=py38h06a4308_1
+  - six=1.15.0=py38h06a4308_0
+  - sqlite=3.33.0=h62c20be_0
+  - tk=8.6.10=hbc83047_0
+  - tornado=6.0.4=py38h7b6447c_1
+  - traitlets=5.0.5=py_0
+  - tzdata=2020d=h14c3975_0
+  - wcwidth=0.2.5=py_0
+  - wheel=0.35.1=pyhd3eb1b0_0
+  - xz=5.2.5=h7b6447c_0
+  - zeromq=4.3.3=he6710b0_3
+  - zlib=1.2.11=h7b6447c_3
+  - pip:
+    - cycler==0.10.0
+    - joblib==0.17.0
+    - kiwisolver==1.3.1
+    - matplotlib==3.3.3
+    - numpy==1.19.4
+    - obp==0.3.3
+    - pandas==1.1.4
+    - pillow==8.0.1
+    - pyparsing==2.4.7
+    - pytz==2020.4
+    - pyyaml==5.3.1
+    - scikit-learn==0.23.2
+    - scipy==1.5.4
+    - seaborn==0.11.0
+    - threadpoolctl==2.1.0
+    - tqdm==4.52.0
+prefix: /scratch/ci411/.conda/envs/sd_bandits_env
+

--- a/scripting/Scripting_Demo_nb.ipynb
+++ b/scripting/Scripting_Demo_nb.ipynb
@@ -1,0 +1,172 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Slurm Experiment Running\n",
+    "\n",
+    "I wrote most of the key experimental organization tools to the ```sd_bandits.utils```directory. Note that I'm using the ```sd_bandits_env``` defined in ```conda_envs/sd_bandits.yml```. Let's start by importing this:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "import os\n",
+    "root_dir = os.path.expanduser('~/sd_bandits')\n",
+    "sys.path.append(root_dir)\n",
+    "\n",
+    "import sd_bandits.utils as utils"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The key functions are:\n",
+    "* ```build_obj_spec()```, which builds a .yml file for a specific policy, estimator, or dataset\n",
+    "* ```load_obj_from_spec()```, which loads a dictionary from the .yml file created with the above function\n",
+    "* ```build_experiment()```, which builds a policy, estimator, and dataset, and constructs a slurm batch submission script"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's say I wanted to test this out on the full ```obp``` dataset w/ the bts policy data:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'name': 'notebook_demo_1', 'type': 'dataset', 'key': 'obp', 'parameters': {'data_path': '~/sd_bandits/data/obd', 'campaign': 'all', 'behavior_policy': 'bts'}}\n"
+     ]
+    }
+   ],
+   "source": [
+    "dataset_name = 'obp'\n",
+    "#this is all the arguments I'd pass to the OBP dataset constructor\n",
+    "dataset_params = {'data_path': '~/sd_bandits/data/obd',\n",
+    "                       'campaign': 'all',\n",
+    "                       'behavior_policy': 'bts'}\n",
+    "\n",
+    "dataset_dict = utils.build_obj_spec(dataset_name, dataset_params, experiment_name='notebook_demo_1',\n",
+    "                                    obj_type='dataset', output='./policy_yamls/')\n",
+    "print(dataset_dict)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "I've also saved this tp ```./policy_yamls/notebook_demo_1/dataset_sepc.yml```. I can load the dataset by:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "OpenBanditDataset(behavior_policy='bts', campaign='all', data_path=PosixPath('~/sd_bandits/data/obd/bts/all'), dataset_name='obd')\n"
+     ]
+    }
+   ],
+   "source": [
+    "dataset = utils.load_obj_from_spec('./policy_yamls/notebook_demo_1/dataset_spec.yaml')\n",
+    "print(dataset)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "I can repeat this for a policy and estimator. For sake of example, I'll do a ```LogisticTS``` policy and a ```DoublyRobustWithShrinkage``` estimator"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "policy_name = 'LogisticTS'\n",
+    "policy_params = {'n_actions':dataset.n_actions, 'len_list':dataset.len_list, 'dim':dataset.context.shape[1]}\n",
+    "policy_dict = utils.build_obj_spec(policy_name, policy_params, experiment_name='notebook_demo_1',\n",
+    "                                    obj_type='policy' , output='./policy_yamls/')\n",
+    "\n",
+    "estimator_name = 'DoublyRobustWithShrinkage'\n",
+    "estimator_params = {'lambda_':1}\n",
+    "estimator_dict = utils.build_obj_spec(estimator_name, estimator_params, experiment_name='notebook_demo_1',\n",
+    "                                      obj_type='estimator' , output='./policy_yamls/')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now, I can run this experiment using the script ```opb_run.py --experiment-dir 'policy_yamls/notebook_demo_1/```, and the resulting interval estimates would be saved in the same directory. For convenience, theres a single function that can generate all three objects, and a script for submitting a job to slurm:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "experiment_test_name = 'notebook_demo_2'\n",
+    "\n",
+    "utils.build_experiment(experiment_test_name, policy_name, estimator_name, dataset_name,\\\n",
+    "                       policy_params, estimator_params, dataset_params)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "From here, ```sbatch ./policy_yamls/notebook_demo_2/script.sbatch``` will submit the job to a slurm node."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "SD_Bandits Py3.8",
+   "language": "python",
+   "name": "sd_bandits_env"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/scripting/example.sbatch
+++ b/scripting/example.sbatch
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+#SBATCH --job-name=ex_jb
+#SBATCH --nodes=1
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=16GB
+#SBATCH --time=100:00:00
+#SBATCH --output="outputs/example.out"
+#SBATCH --export=NONE
+
+module purge
+module load anaconda3/4.3.1
+
+source activate sd_bandits_env
+
+cd ~/sd_bandits/scripting/
+
+python opb_run.py --policy EpsilonGreedy --estimator ReplayMethod

--- a/scripting/opb_run.py
+++ b/scripting/opb_run.py
@@ -1,0 +1,136 @@
+import sys
+import os
+import numpy as np
+import argparse
+from pathlib import Path
+
+#loading the custom deezer datset
+#assumes your sd_bandits directory is in your root directory,
+#change root_dir if not
+root_dir = os.path.join('~', 'sd_bandits/')
+sys.path.append(root_dir)
+
+from obp.dataset import OpenBanditDataset
+#from sd_bandits.deezer.dataset import DeezerDataset
+from obp.policy import BernoulliTS, EpsilonGreedy, Random, LinEpsilonGreedy, LinTS, LinUCB, LogisticEpsilonGreedy, LogisticTS, LogisticUCB
+
+from obp.ope.estimators import DirectMethod, DoublyRobust, DoublyRobustWithShrinkage, InverseProbabilityWeighting, ReplayMethod, SelfNormalizedDoublyRobust, SelfNormalizedInverseProbabilityWeighting, SwitchDoublyRobust, SwitchInverseProbabilityWeighting
+
+from obp.simulator.simulator import run_bandit_simulation
+
+#for loading policies, to be changed to include custom policies
+policy_dict = {'BernoulliTS':BernoulliTS,
+               'EpsilonGreedy':EpsilonGreedy,
+               'Random':Random,
+               'LinEpsilonGreedy':LinEpsilonGreedy,
+               'LinTS':LinTS,
+               'LinUCB':LinUCB,
+               'LogisticEpsilonGreedy':LogisticEpsilonGreedy,
+               'LogisticTS':LogisticTS,
+               'LogisticUCB':LogisticUCB}
+
+estimator_dict = {'DirectMethod':DirectMethod,
+                  'DoublyRobust':DoublyRobust,
+                  'DoublyRobustWithShrinkage':DoublyRobustWithShrinkage,
+                  'InverseProbabilityWeighting':InverseProbabilityWeighting,
+                  'ReplayMethod':ReplayMethod,
+                  'SelfNormalizedDoublyRobust':SelfNormalizedDoublyRobust,
+                  'SelfNormalizedInverseProbabilityWeighting':SelfNormalizedInverseProbabilityWeighting,
+                  'SwitchDoublyRobust':SwitchDoublyRobust,
+                  'SwitchInverseProbabilityWeighting':SwitchInverseProbabilityWeighting}
+
+
+def process_arguments(args):
+    parser = argparse.ArgumentParser(description=__doc__)
+
+    parser.add_argument('--dataset-name',
+                        dest='dataset_name', type=str, default='obd',
+                        help='The dataset (either "obd" or "deezer")')
+    
+    parser.add_argument('--dataset-path',
+                        dest='dataset_path', type=str,
+                        default=os.path.join(root_dir, 'data/obd'),
+                        help='Path pointing to the dataset')
+    
+    parser.add_argument('--policy',
+                        dest='policy', type=str,
+                        default='BernoulliTS',
+                        help='Policy to use for actions')
+    
+    parser.add_argument('--estimator',
+                        dest='estimator', type=str,
+                        default='ReplayMethod',
+                        help='Estimator to use for evaluation')
+    
+    parser.add_argument('--rng-seed',
+                        dest='rng_seed', type=int, default=11192020,
+                        help='RNG seed for replication')
+    
+    parser.add_argument('--campaign',
+                        dest='campaign', type=str,
+                        default='all',
+                        help='Campaign of OBD (can be all, men, women)')
+    
+    parser.add_argument('--obd-policy',
+                        dest='obd_policy', type=str,
+                        default='random',
+                        help='Policy used to generate OBD (random or bts)')
+    
+    parser.add_argument('--user-features',
+                        dest='user_features', type=str,
+                        default='user_features_small.csv',
+                        help='Deezer user features file')
+
+    parser.add_argument('--playlist-features',
+                        dest='playlist_features', type=str,
+                        default='playlist_features.csv',
+                        help='Deezer playlist features file')
+        
+    return parser.parse_args(args)
+
+if __name__ == '__main__':
+    params = process_arguments(sys.argv[1:])
+
+    #load the dataset (obd or deezer)
+    print("Loading dataset")
+    if params.dataset_name=='obd':
+        dataset = OpenBanditDataset(data_path=Path(params.dataset_path),
+                                    campaign=params.campaign,
+                                    behavior_policy=params.obd_policy)
+    elif params.dataset_name=='deezer':
+        user_features = os.path.join(params.dataset_path, params.user_features)
+        playlist_features = os.path.join(params.dataset_path, params.playlist_features)
+        dataset = DeezerDataset(user_features=user_features,
+                                playlist_feature=playlist_features)
+    else:
+        print('Invalid dataset name "{}"'.format(params.dataset_name))
+    
+    #grab logged bandit feedback from dataset
+    feedback = dataset.obtain_batch_bandit_feedback()
+    
+    #build policy
+    print("Constructing Policy")
+    policy_constructor = policy_dict[params.policy]
+    
+    #TODO add modularity for kwargs from argparse for hyperparameter adjustments
+    policy = policy_constructor(n_actions=dataset.n_actions,
+                                len_list = dataset.len_list)
+    
+    #compute action probabilities
+    actions = run_bandit_simulation(bandit_feedback=feedback,
+                                    policy=policy)
+
+    #evaluate policy
+    #TODO add modularity for kwargs for argparse for estimator adjustments
+    print("Evaluating results")
+    estimator = estimator_dict[params.estimator]()
+    results = estimator.estimate_interval(reward=feedback["reward"],
+                                          action=feedback["action"],
+                                          position=feedback["position"],
+                                          action_dist=actions)
+    
+    ground_truth_mean = feedback["reward"].mean()
+    print('Ground truth mean value: {}'.format(ground_truth_mean))
+    print('{} policy mean value: {}'.format(params.policy, results['mean']))
+    
+    #TODO Dump results to file

--- a/scripting/opb_run.py
+++ b/scripting/opb_run.py
@@ -3,128 +3,55 @@ import os
 import numpy as np
 import argparse
 from pathlib import Path
+from obp.simulator.simulator import run_bandit_simulation
 
 #loading the custom deezer datset
 #assumes your sd_bandits directory is in your root directory,
 #change root_dir if not
-root_dir = os.path.join('~', 'sd_bandits/')
+root_dir = os.path.expanduser('~/sd_bandits')
 sys.path.append(root_dir)
+import sd_bandits.utils as utils
 
-from obp.dataset import OpenBanditDataset
-#from sd_bandits.deezer.dataset import DeezerDataset
-from obp.policy import BernoulliTS, EpsilonGreedy, Random, LinEpsilonGreedy, LinTS, LinUCB, LogisticEpsilonGreedy, LogisticTS, LogisticUCB
-
-from obp.ope.estimators import DirectMethod, DoublyRobust, DoublyRobustWithShrinkage, InverseProbabilityWeighting, ReplayMethod, SelfNormalizedDoublyRobust, SelfNormalizedInverseProbabilityWeighting, SwitchDoublyRobust, SwitchInverseProbabilityWeighting
-
-from obp.simulator.simulator import run_bandit_simulation
-
-#for loading policies, to be changed to include custom policies
-policy_dict = {'BernoulliTS':BernoulliTS,
-               'EpsilonGreedy':EpsilonGreedy,
-               'Random':Random,
-               'LinEpsilonGreedy':LinEpsilonGreedy,
-               'LinTS':LinTS,
-               'LinUCB':LinUCB,
-               'LogisticEpsilonGreedy':LogisticEpsilonGreedy,
-               'LogisticTS':LogisticTS,
-               'LogisticUCB':LogisticUCB}
-
-estimator_dict = {'DirectMethod':DirectMethod,
-                  'DoublyRobust':DoublyRobust,
-                  'DoublyRobustWithShrinkage':DoublyRobustWithShrinkage,
-                  'InverseProbabilityWeighting':InverseProbabilityWeighting,
-                  'ReplayMethod':ReplayMethod,
-                  'SelfNormalizedDoublyRobust':SelfNormalizedDoublyRobust,
-                  'SelfNormalizedInverseProbabilityWeighting':SelfNormalizedInverseProbabilityWeighting,
-                  'SwitchDoublyRobust':SwitchDoublyRobust,
-                  'SwitchInverseProbabilityWeighting':SwitchInverseProbabilityWeighting}
 
 
 def process_arguments(args):
     parser = argparse.ArgumentParser(description=__doc__)
 
-    parser.add_argument('--dataset-name',
-                        dest='dataset_name', type=str, default='obd',
-                        help='The dataset (either "obd" or "deezer")')
-    
-    parser.add_argument('--dataset-path',
-                        dest='dataset_path', type=str,
-                        default=os.path.join(root_dir, 'data/obd'),
-                        help='Path pointing to the dataset')
-    
-    parser.add_argument('--policy',
-                        dest='policy', type=str,
-                        default='BernoulliTS',
-                        help='Policy to use for actions')
-    
-    parser.add_argument('--estimator',
-                        dest='estimator', type=str,
-                        default='ReplayMethod',
-                        help='Estimator to use for evaluation')
+    parser.add_argument('--experiment-dir',
+                        dest='experiment_dir', type=str, ,
+                        help='The directory containing the experiment design')
     
     parser.add_argument('--rng-seed',
                         dest='rng_seed', type=int, default=11192020,
                         help='RNG seed for replication')
     
-    parser.add_argument('--campaign',
-                        dest='campaign', type=str,
-                        default='all',
-                        help='Campaign of OBD (can be all, men, women)')
-    
-    parser.add_argument('--obd-policy',
-                        dest='obd_policy', type=str,
-                        default='random',
-                        help='Policy used to generate OBD (random or bts)')
-    
-    parser.add_argument('--user-features',
-                        dest='user_features', type=str,
-                        default='user_features_small.csv',
-                        help='Deezer user features file')
-
-    parser.add_argument('--playlist-features',
-                        dest='playlist_features', type=str,
-                        default='playlist_features.csv',
-                        help='Deezer playlist features file')
         
     return parser.parse_args(args)
 
 if __name__ == '__main__':
     params = process_arguments(sys.argv[1:])
 
-    #load the dataset (obd or deezer)
-    print("Loading dataset")
-    if params.dataset_name=='obd':
-        dataset = OpenBanditDataset(data_path=Path(params.dataset_path),
-                                    campaign=params.campaign,
-                                    behavior_policy=params.obd_policy)
-    elif params.dataset_name=='deezer':
-        user_features = os.path.join(params.dataset_path, params.user_features)
-        playlist_features = os.path.join(params.dataset_path, params.playlist_features)
-        dataset = DeezerDataset(user_features=user_features,
-                                playlist_feature=playlist_features)
-    else:
-        print('Invalid dataset name "{}"'.format(params.dataset_name))
+    dataset_spec_path = os.path.join(params.experiment_dir, 'dataset_spec.yaml')
+    dataset = load_obj_from_spec(datset_spec_path)
     
     #grab logged bandit feedback from dataset
     feedback = dataset.obtain_batch_bandit_feedback()
     
     #build policy
-    print("Constructing Policy")
-    policy_constructor = policy_dict[params.policy]
-    
-    #TODO add modularity for kwargs from argparse for hyperparameter adjustments
-    policy = policy_constructor(n_actions=dataset.n_actions,
-                                len_list = dataset.len_list)
+    policy_spec_path = os.path.join(params.experiment_dir, 'policy_spec.yaml')
+    policy = load_obj_from_spec(policy_spec_path)
     
     #compute action probabilities
     actions = run_bandit_simulation(bandit_feedback=feedback,
                                     policy=policy)
 
     #evaluate policy
-    #TODO add modularity for kwargs for argparse for estimator adjustments
-    print("Evaluating results")
-    estimator = estimator_dict[params.estimator]()
-    results = estimator.estimate_interval(reward=feedback["reward"],
+    estimator_spec_path = os.path.join(params.experiment_dir, 'estimator_spec.yaml')
+    estimator = load_obj_from_spec(estimator_spec_path)
+    
+    
+    #TODO update this for all estimators
+    interval_results = estimator.estimate_interval(reward=feedback["reward"],
                                           action=feedback["action"],
                                           position=feedback["position"],
                                           action_dist=actions)

--- a/scripting/outputs/example.out
+++ b/scripting/outputs/example.out
@@ -1,0 +1,6 @@
+  0%|          | 0/10000 [00:00<?, ?it/s]  0%|          | 1/10000 [00:00<24:59,  6.67it/s] 63%|██████▎   | 6276/10000 [00:00<06:31,  9.52it/s]100%|██████████| 10000/10000 [00:00<00:00, 32397.83it/s]
+Loading dataset
+Constructing Policy
+Evaluating results
+Ground truth mean value: 0.0038
+EpsilonGreedy policy mean value: 0.0

--- a/scripting/policy_yamls/save_obj_test/dataset_spec.yaml
+++ b/scripting/policy_yamls/save_obj_test/dataset_spec.yaml
@@ -1,0 +1,7 @@
+key: obp
+name: save_obj_test
+parameters:
+  behavior_policy: bts
+  campaign: all
+  data_path: ~/sd_bandits/data/obd
+type: dataset

--- a/scripting/policy_yamls/save_obj_test/estimator_spec.yaml
+++ b/scripting/policy_yamls/save_obj_test/estimator_spec.yaml
@@ -1,0 +1,5 @@
+key: DoublyRobustWithShrinkage
+name: save_obj_test
+parameters:
+  lambda_: 1
+type: estimator

--- a/scripting/policy_yamls/save_obj_test/policy_spec.yaml
+++ b/scripting/policy_yamls/save_obj_test/policy_spec.yaml
@@ -1,0 +1,7 @@
+key: BernoulliTS
+name: save_obj_test
+parameters:
+  batch_size: 5
+  len_list: 3
+  n_actions: 5
+type: policy

--- a/scripting/policy_yamls/save_obj_test/results.yaml
+++ b/scripting/policy_yamls/save_obj_test/results.yaml
@@ -1,0 +1,25 @@
+95.0% CI (lower): !!python/object/apply:numpy.core.multiarray.scalar
+- &id001 !!python/object/apply:numpy.dtype
+  args:
+  - f8
+  - false
+  - true
+  state: !!python/tuple
+  - 3
+  - <
+  - null
+  - null
+  - null
+  - -1
+  - -1
+  - 0
+- !!binary |
+  afzBAJ0Baj8=
+95.0% CI (upper): !!python/object/apply:numpy.core.multiarray.scalar
+- *id001
+- !!binary |
+  wfNm4gz0az8=
+mean: !!python/object/apply:numpy.core.multiarray.scalar
+- *id001
+- !!binary |
+  XBjNEhH7aj8=

--- a/scripting/yaml_prototyping.ipynb
+++ b/scripting/yaml_prototyping.ipynb
@@ -1,0 +1,466 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "import os\n",
+    "import numpy as np\n",
+    "import argparse\n",
+    "from pathlib import Path\n",
+    "from datetime import datetime\n",
+    "import yaml\n",
+    "\n",
+    "root_dir = os.path.expanduser('~/sd_bandits')\n",
+    "sys.path.append(root_dir)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sd_bandits.utils"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from obp.policy import BernoulliTS, EpsilonGreedy, Random, LinEpsilonGreedy,\\\n",
+    "                       LinTS, LinUCB, LogisticEpsilonGreedy, LogisticTS, LogisticUCB\n",
+    "\n",
+    "from obp.ope.estimators import DirectMethod, DoublyRobust, DoublyRobustWithShrinkage,\\\n",
+    "                               InverseProbabilityWeighting, ReplayMethod,\\\n",
+    "                               SelfNormalizedDoublyRobust, SelfNormalizedInverseProbabilityWeighting,\\\n",
+    "                               SwitchDoublyRobust, SwitchInverseProbabilityWeighting\n",
+    "\n",
+    "from obp.dataset import OpenBanditDataset\n",
+    "from sd_bandits.deezer.dataset import DeezerDataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    }
+   },
+   "outputs": [],
+   "source": [
+    "policy_dict = {'BernoulliTS':BernoulliTS,\n",
+    "               'EpsilonGreedy':EpsilonGreedy,\n",
+    "               'Random':Random,\n",
+    "               'LinEpsilonGreedy':LinEpsilonGreedy,\n",
+    "               'LinTS':LinTS,\n",
+    "               'LinUCB':LinUCB,\n",
+    "               'LogisticEpsilonGreedy':LogisticEpsilonGreedy,\n",
+    "               'LogisticTS':LogisticTS,\n",
+    "               'LogisticUCB':LogisticUCB}\n",
+    "\n",
+    "def build_policy_spec(policy_key, parameter_dict, policy_name=None, output='./policy_yamls/'):\n",
+    "    '''\n",
+    "    Constructs a yaml output file specifying the type of \n",
+    "    policy and the policy paramters\n",
+    "    \n",
+    "    Parameters\n",
+    "    ------------\n",
+    "    policy_key: str\n",
+    "        The policy name\n",
+    "    parameter_dict: dict\n",
+    "        The dict containing {kwarg: value}\n",
+    "    policy_name: str\n",
+    "        The name of the policy+configuration, if not\n",
+    "        specified, will be automatically generated\n",
+    "        via timestamp\n",
+    "    output: str\n",
+    "        Path to directory to store\n",
+    "    \n",
+    "    Returns\n",
+    "    ------------\n",
+    "    policy: policy\n",
+    "        The policy with specified parameters\n",
+    "    '''\n",
+    "    #Set name via timestamp if not specified\n",
+    "    if policy_name==None:\n",
+    "        now = datetime.now()\n",
+    "        current_time = now.strftime(\"%H%M%S\")\n",
+    "        policy_name = '{}_{}'.format(policy_key, current_time)\n",
+    "    \n",
+    "    #Build dict structure\n",
+    "    yaml_dict = {}\n",
+    "    yaml_dict['name'] = policy_name\n",
+    "    yaml_dict['policy_type'] = policy_key\n",
+    "    yaml_dict['parameters'] = parameter_dict\n",
+    "    \n",
+    "    #Set output folder\n",
+    "    output_folder = os.path.join(output, policy_name)\n",
+    "    if not os.path.exists(output_folder):\n",
+    "        os.makedirs(output_folder)\n",
+    "    \n",
+    "    with open(os.path.join(output_folder, 'policy_spec.yaml'), 'w') as file:\n",
+    "        yaml.dump(yaml_dict, file)\n",
+    "        \n",
+    "    policy = policy_dict[policy_key](**parameter_dict)\n",
+    "    \n",
+    "    return policy\n",
+    "    \n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "BernoulliTS(n_actions=5, len_list=3, batch_size=5, random_state=None, alpha=array([1., 1., 1., 1., 1.]), beta=array([1., 1., 1., 1., 1.]), is_zozotown_prior=False, campaign=None, policy_name='bts')\n"
+     ]
+    }
+   ],
+   "source": [
+    "policy_key_test = 'BernoulliTS'\n",
+    "policy_name_test = 'Bernoulli_test'\n",
+    "policy_params_test = {'n_actions':5, 'len_list':3, 'batch_size':5}\n",
+    "\n",
+    "policy_test = build_policy_spec(policy_key_test, policy_params_test,\\\n",
+    "                  policy_name=policy_name_test)\n",
+    "\n",
+    "print(policy_test)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def load_policy_from_spec(policy_folder):\n",
+    "    '''\n",
+    "    Constructs a yaml output file specifying the type of \n",
+    "    policy and the policy paramters\n",
+    "    \n",
+    "    Parameters\n",
+    "    ------------\n",
+    "    policy_folder: str\n",
+    "        The folder containing the policy spec\n",
+    "    Returns\n",
+    "    ------------\n",
+    "    policy: policy\n",
+    "        The policy loaded from the spec yaml\n",
+    "    '''\n",
+    "    with open(os.path.join(policy_folder, 'policy_spec.yaml'), 'r') as file:\n",
+    "        yaml_dict = yaml.load(file)\n",
+    "    \n",
+    "    policy_key = yaml_dict['policy_type']\n",
+    "    parameter_dict = yaml_dict['parameters']\n",
+    "    \n",
+    "    policy = policy_dict[policy_key](**parameter_dict)\n",
+    "   \n",
+    "    return policy\n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "BernoulliTS(n_actions=5, len_list=3, batch_size=5, random_state=None, alpha=array([1., 1., 1., 1., 1.]), beta=array([1., 1., 1., 1., 1.]), is_zozotown_prior=False, campaign=None, policy_name='bts')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "<ipython-input-25-fd36e1bd954d>:16: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.\n",
+      "  yaml_dict = yaml.load(file)\n"
+     ]
+    }
+   ],
+   "source": [
+    "policy_load_test = './policy_yamls/Bernoulli_test'\n",
+    "\n",
+    "policy_load = load_policy_from_spec(policy_load_test)\n",
+    "print(policy_load)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "estimator_dict = {'DirectMethod':DirectMethod,\n",
+    "                  'DoublyRobust':DoublyRobust,\n",
+    "                  'DoublyRobustWithShrinkage':DoublyRobustWithShrinkage,\n",
+    "                  'InverseProbabilityWeighting':InverseProbabilityWeighting,\n",
+    "                  'ReplayMethod':ReplayMethod,\n",
+    "                  'SelfNormalizedDoublyRobust':SelfNormalizedDoublyRobust,\n",
+    "                  'SelfNormalizedInverseProbabilityWeighting':SelfNormalizedInverseProbabilityWeighting,\n",
+    "                  'SwitchDoublyRobust':SwitchDoublyRobust,\n",
+    "                  'SwitchInverseProbabilityWeighting':SwitchInverseProbabilityWeighting}\n",
+    "\n",
+    "policy_dict = {'BernoulliTS':BernoulliTS,\n",
+    "               'EpsilonGreedy':EpsilonGreedy,\n",
+    "               'Random':Random,\n",
+    "               'LinEpsilonGreedy':LinEpsilonGreedy,\n",
+    "               'LinTS':LinTS,\n",
+    "               'LinUCB':LinUCB,\n",
+    "               'LogisticEpsilonGreedy':LogisticEpsilonGreedy,\n",
+    "               'LogisticTS':LogisticTS,\n",
+    "               'LogisticUCB':LogisticUCB}\n",
+    "\n",
+    "dataset_dict = {'obp': OpenBanditDataset,\n",
+    "                'deezer': DeezerDataset}\n",
+    "\n",
+    "\n",
+    "def build_obj_spec(obj_key, parameter_dict, experiment_name=None, obj_type='policy', output='./policy_yamls/'):\n",
+    "    '''\n",
+    "    Constructs a yaml output file specifying the type of \n",
+    "    policy and the policy paramters\n",
+    "    \n",
+    "    Parameters\n",
+    "    ------------\n",
+    "    obj_key: str\n",
+    "        The policy/estimator/dataset name\n",
+    "    parameter_dict: dict\n",
+    "        The dict containing parameters for the\n",
+    "        obp object {kwarg: value}\n",
+    "    experiment_name: str\n",
+    "        The associated experiment name, if not\n",
+    "        specified, will be automatically generated\n",
+    "        via timestamp\n",
+    "    obj_type: str\n",
+    "        The type of OBP object, should be 'policy'\n",
+    "        or 'estimator', throw error otherwise\n",
+    "    output: str\n",
+    "        Path to directory to store\n",
+    "    \n",
+    "    Returns\n",
+    "    ------------\n",
+    "    obj_dict: dict\n",
+    "        The constructor dict for the object\n",
+    "    '''\n",
+    "    #Set name via timestamp if not specified\n",
+    "    if obj_type not in ['policy','estimator', 'dataset']:\n",
+    "        print('Invalid type: {}'.format(obj_type))\n",
+    "        return None\n",
+    "    \n",
+    "    if experiment_name==None:\n",
+    "        now = datetime.now()\n",
+    "        current_time = now.strftime(\"%H%M%S\")\n",
+    "        experiment_name = 'experiment_{}'.format(current_time)\n",
+    "    \n",
+    "    #Build dict structure\n",
+    "    obj_dict = {}\n",
+    "    obj_dict['name'] = experiment_name\n",
+    "    obj_dict['type'] = obj_type\n",
+    "    obj_dict['key'] = obj_key\n",
+    "    obj_dict['parameters'] = parameter_dict\n",
+    "    \n",
+    "    #Set output folder\n",
+    "    output_folder = os.path.join(output, experiment_name)\n",
+    "    if not os.path.exists(output_folder):\n",
+    "        os.makedirs(output_folder)\n",
+    "    \n",
+    "    with open(os.path.join(output_folder, '{}_spec.yaml'.format(obj_type)), 'w') as file:\n",
+    "        yaml.dump(obj_dict, file)\n",
+    "        \n",
+    "    return obj_dict"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def load_obj_from_spec(obj_dict_path):\n",
+    "    '''\n",
+    "    Loads policy/estimator from spec dict\n",
+    "    \n",
+    "    Parameters\n",
+    "    ------------\n",
+    "    obj_dict_path: str\n",
+    "        Path to configuration dict from build_obj_spec()\n",
+    "    Returns\n",
+    "    ------------\n",
+    "    obj: obp.policy/obp.estimator/dataset\n",
+    "        The policy/estimator loaded from the spec dict\n",
+    "    '''\n",
+    "    with open(obj_dict_path, 'r') as file:\n",
+    "        obj_dict = yaml.load(file, Loader=yaml.FullLoader)\n",
+    "        \n",
+    "    obj_name = obj_dict['name']\n",
+    "    obj_type = obj_dict['type']\n",
+    "    obj_key = obj_dict['key']\n",
+    "    parameter_dict = obj_dict['parameters']\n",
+    "    \n",
+    "    if obj_type=='policy':\n",
+    "        policy = policy_dict[obj_key](**parameter_dict)\n",
+    "        return policy\n",
+    "    elif obj_type=='estimator':\n",
+    "        estimator = estimator_dict[obj_key](**parameter_dict)\n",
+    "        return estimator\n",
+    "    elif obj_type=='dataset':\n",
+    "        parameter_dict['data_path'] = Path(parameter_dict['data_path'])\n",
+    "        dataset = dataset_dict[obj_key](**parameter_dict)\n",
+    "        return dataset\n",
+    "   "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'name': 'save_obj_test', 'type': 'policy', 'key': 'BernoulliTS', 'parameters': {'n_actions': 5, 'len_list': 3, 'batch_size': 5}}\n",
+      "BernoulliTS(n_actions=5, len_list=3, batch_size=5, random_state=None, alpha=array([1., 1., 1., 1., 1.]), beta=array([1., 1., 1., 1., 1.]), is_zozotown_prior=False, campaign=None, policy_name='bts')\n"
+     ]
+    }
+   ],
+   "source": [
+    "policy_key_test = 'BernoulliTS'\n",
+    "policy_name_test = 'save_obj_test'\n",
+    "policy_params_test = {'n_actions':5, 'len_list':3, 'batch_size':5}\n",
+    "\n",
+    "policy_test = build_obj_spec(policy_key_test, policy_params_test, experiment_name=policy_name_test)\n",
+    "\n",
+    "print(policy_test)\n",
+    "print(load_obj_from_spec('policy_yamls/save_obj_test/policy_spec.yaml'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'name': 'save_obj_test', 'type': 'estimator', 'key': 'DoublyRobustWithShrinkage', 'parameters': {'lambda_': 1}}\n",
+      "DoublyRobustWithShrinkage(estimator_name='dr-os', lambda_=1)\n"
+     ]
+    }
+   ],
+   "source": [
+    "est_key_test = 'DoublyRobustWithShrinkage'\n",
+    "est_name_test = 'save_obj_test'\n",
+    "est_params_test = {'lambda_':1}\n",
+    "\n",
+    "est_test = build_obj_spec(est_key_test, est_params_test, experiment_name=est_name_test, obj_type='estimator')\n",
+    "\n",
+    "print(est_test)\n",
+    "print(load_obj_from_spec('policy_yamls/save_obj_test/estimator_spec.yaml'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'name': 'save_obj_test', 'type': 'dataset', 'key': 'obp', 'parameters': {'data_path': '~/sd_bandits/data/obd', 'campaign': 'all', 'behavior_policy': 'bts'}}\n",
+      "OpenBanditDataset(behavior_policy='bts', campaign='all', data_path=PosixPath('~/sd_bandits/data/obd/bts/all'), dataset_name='obd')\n"
+     ]
+    }
+   ],
+   "source": [
+    "dataset_key_test = 'obp'\n",
+    "dataset_name_test = 'save_obj_test'\n",
+    "dataset_params_test = {'data_path': '~/sd_bandits/data/obd',\n",
+    "                       'campaign': 'all',\n",
+    "                       'behavior_policy': 'bts'}\n",
+    "\n",
+    "dataset_test = build_obj_spec(dataset_key_test, dataset_params_test, experiment_name=dataset_name_test, obj_type='dataset')\n",
+    "\n",
+    "print(dataset_test)\n",
+    "print(load_obj_from_spec('policy_yamls/save_obj_test/dataset_spec.yaml'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def build_experiment(experiment_name, policy, estimator, dataset, policy_params, estimator_params, dataset_params):\n",
+    "    '''\n",
+    "    Builds full experiment spec folder w/ policy, estimator, and dataset, as well as an\n",
+    "    \n",
+    "    Parameters\n",
+    "    ------------\n",
+    "    obj_dict: dict\n",
+    "        Obj configuration dict from build_obj_spec()\n",
+    "    Returns\n",
+    "    ------------\n",
+    "    obj: obp.policy/obp.estimator\n",
+    "        The policy/estimator loaded from the spec dict\n",
+    "    ''' "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "SD_Bandits Py3.8",
+   "language": "python",
+   "name": "sd_bandits_env"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/sd_bandits/utils.py
+++ b/sd_bandits/utils.py
@@ -1,0 +1,127 @@
+import os
+from datetime import datetime
+import yaml
+import sys
+root_dir = os.path.expanduser('~/sd_bandits')
+sys.path.append(root_dir)
+
+from obp.policy import BernoulliTS, EpsilonGreedy, Random, LinEpsilonGreedy,\
+                       LinTS, LinUCB, LogisticEpsilonGreedy, LogisticTS, LogisticUCB
+
+from obp.ope.estimators import DirectMethod, DoublyRobust, DoublyRobustWithShrinkage,\
+                               InverseProbabilityWeighting, ReplayMethod,\
+                               SelfNormalizedDoublyRobust, SelfNormalizedInverseProbabilityWeighting,\
+                               SwitchDoublyRobust, SwitchInverseProbabilityWeighting
+
+from obp.dataset import OpenBanditDataset
+from sd_bandits.deezer.dataset import DeezerDataset
+
+policy_dict = {'BernoulliTS':BernoulliTS,
+               'EpsilonGreedy':EpsilonGreedy,
+               'Random':Random,
+               'LinEpsilonGreedy':LinEpsilonGreedy,
+               'LinTS':LinTS,
+               'LinUCB':LinUCB,
+               'LogisticEpsilonGreedy':LogisticEpsilonGreedy,
+               'LogisticTS':LogisticTS,
+               'LogisticUCB':LogisticUCB}
+
+estimator_dict = {'DirectMethod':DirectMethod,
+                  'DoublyRobust':DoublyRobust,
+                  'DoublyRobustWithShrinkage':DoublyRobustWithShrinkage,
+                  'InverseProbabilityWeighting':InverseProbabilityWeighting,
+                  'ReplayMethod':ReplayMethod,
+                  'SelfNormalizedDoublyRobust':SelfNormalizedDoublyRobust,
+                  'SelfNormalizedInverseProbabilityWeighting':SelfNormalizedInverseProbabilityWeighting,
+                  'SwitchDoublyRobust':SwitchDoublyRobust,
+                  'SwitchInverseProbabilityWeighting':SwitchInverseProbabilityWeighting}
+
+dataset_dict = {'obp': OpenBanditDataset,
+                'deezer': DeezerDataset}
+
+
+def build_obj_spec(obj_key, parameter_dict, experiment_name=None, obj_type='policy', output='./policy_yamls/'):
+    '''
+    Constructs a yaml output file specifying the type of 
+    policy and the policy paramters
+    
+    Parameters
+    ------------
+    obj_key: str
+        The policy/estimator/dataset name
+    parameter_dict: dict
+        The dict containing parameters for the
+        obp object {kwarg: value}
+    experiment_name: str
+        The associated experiment name, if not
+        specified, will be automatically generated
+        via timestamp
+    obj_type: str
+        The type of OBP object, should be 'policy'
+        or 'estimator', throw error otherwise
+    output: str
+        Path to directory to store
+    
+    Returns
+    ------------
+    obj_dict: dict
+        The constructor dict for the object
+    '''
+    #Set name via timestamp if not specified
+    if obj_type not in ['policy','estimator', 'dataset']:
+        print('Invalid type: {}'.format(obj_type))
+        return None
+    
+    if experiment_name==None:
+        now = datetime.now()
+        current_time = now.strftime("%H%M%S")
+        experiment_name = 'experiment_{}'.format(current_time)
+    
+    #Build dict structure
+    obj_dict = {}
+    obj_dict['name'] = experiment_name
+    obj_dict['type'] = obj_type
+    obj_dict['key'] = obj_key
+    obj_dict['parameters'] = parameter_dict
+    
+    #Set output folder
+    output_folder = os.path.join(output, experiment_name)
+    if not os.path.exists(output_folder):
+        os.makedirs(output_folder)
+    
+    with open(os.path.join(output_folder, '{}_spec.yaml'.format(obj_type)), 'w') as file:
+        yaml.dump(obj_dict, file)
+        
+    return obj_dict
+
+
+def load_obj_from_spec(obj_dict_path):
+    '''
+    Loads policy/estimator from spec dict
+    
+    Parameters
+    ------------
+    obj_dict_path: str
+        Path to configuration dict from build_obj_spec()
+    Returns
+    ------------
+    obj: obp.policy/obp.estimator/dataset
+        The policy/estimator loaded from the spec dict
+    '''
+    with open(obj_dict_path, 'r') as file:
+        obj_dict = yaml.load(file, Loader=yaml.FullLoader)
+        
+    obj_name = obj_dict['name']
+    obj_type = obj_dict['type']
+    obj_key = obj_dict['key']
+    parameter_dict = obj_dict['parameters']
+    
+    if obj_type=='policy':
+        policy = policy_dict[obj_key](**parameter_dict)
+        return policy
+    elif obj_type=='estimator':
+        estimator = estimator_dict[obj_key](**parameter_dict)
+        return estimator
+    elif obj_type=='dataset':
+        dataset = dataset_dict[obj_key](**parameter_dict)
+        return dataset


### PR DESCRIPTION
Added a few things:

- `sd_bandits.utils` has some automation tools for building yamls specifying details for policies, estimators, and datasets
- `scripting/opb_run.py` is a script that runs an experiment from spec yaml files built from the automation tools in `sd_bandits.utils`
- `Scripting_Demo_nb.ipynb` has an explanation on how to use the automation tools in `sd_bandits.utils`
- `conda_envs/sd_bandits.yml ` has a conda env, so at least we're on the same page

Let me know if you have any questions or feature requests/changes.