### PR TITLE
Improve Experiment class, expose round rewards for OBD and Deezer.

### DIFF
--- a/experiments/deezer_demo/dataset_spec.yaml
+++ b/experiments/deezer_demo/dataset_spec.yaml
@@ -3,4 +3,3 @@ name: deezer_demo
 parameters:
   user_features: "/Users/danturkel/Dropbox (Personal)/Grad School/Search and Discovery/sd_bandits/data/deezer_carousel_bandits/user_features.csv"
   playlist_features: "/Users/danturkel/Dropbox (Personal)/Grad School/Search and Discovery/sd_bandits/data/deezer_carousel_bandits/playlist_features.csv"
-type: dataset

--- a/experiments/deezer_demo/policy_spec.yaml
+++ b/experiments/deezer_demo/policy_spec.yaml
@@ -1,10 +1,18 @@
+- key: Random
+  name: deezer_demo
+  parameters:
+    len_list: 12
+    n_actions: 862
+  meta:
+    users_per_batch: 1000
 - key: BernoulliTS
   name: deezer_demo
   parameters:
     batch_size: 1
     len_list: 12
     n_actions: 862
-  type: policy
+  meta:
+    users_per_batch: 1000
 - key: EpsilonGreedy
   name: deezer_demo
   parameters:
@@ -13,4 +21,5 @@
     len_list: 12
     n_actions: 862
     policy_name: "egreedy_0.1"
-  type: policy
+  meta:
+    users_per_batch: 1000

--- a/experiments/obd_demo/dataset_spec.yaml
+++ b/experiments/obd_demo/dataset_spec.yaml
@@ -4,4 +4,3 @@ parameters:
   behavior_policy: random
   campaign: men
   data_path: /Users/danturkel/Dropbox (Personal)/Grad School/Search and Discovery/sd_bandits/data/open_bandit_dataset
-type: dataset

--- a/experiments/obd_demo/estimator_spec.yaml
+++ b/experiments/obd_demo/estimator_spec.yaml
@@ -2,4 +2,3 @@ key: DoublyRobustWithShrinkage
 name: obd_demo
 parameters:
   lambda_: 1
-type: estimator

--- a/experiments/obd_demo/policy_spec.yaml
+++ b/experiments/obd_demo/policy_spec.yaml
@@ -4,7 +4,6 @@
     batch_size: 5
     len_list: 3
     n_actions: 3
-  type: policy
 - key: LinUCB
   name: obd_demo
   parameters:
@@ -12,4 +11,3 @@
     batch_size: 5
     len_list: 3
     n_actions: 3
-  type: policy

--- a/notebooks/Experiments 2 - Scripting Experiments.ipynb
+++ b/notebooks/Experiments 2 - Scripting Experiments.ipynb
@@ -57,15 +57,13 @@
       "    batch_size: 5\n",
       "    len_list: 3\n",
       "    n_actions: 3\n",
-      "  type: policy\n",
       "- key: LinUCB\n",
       "  name: obd_demo\n",
       "  parameters:\n",
       "    dim: 27\n",
       "    batch_size: 5\n",
       "    len_list: 3\n",
-      "    n_actions: 3\n",
-      "  type: policy\n"
+      "    n_actions: 3\n"
      ]
     }
    ],
@@ -89,28 +87,29 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "9:58:54 INFO: Building dataset\n",
-      "9:58:56 INFO: Building policies\n",
-      "9:58:56 INFO: Building estimators\n",
-      "9:58:56 INFO: Running experiment\n",
-      "9:58:56 INFO: Obtaining logged feedback\n",
-      "9:58:56 INFO: Done in 0.0 seconds\n",
-      "9:58:56 INFO: Fitting regression model\n",
-      "9:59:04 INFO: Done in 7.76 seconds\n",
-      "9:59:04 INFO: Running simulations\n",
-      "9:59:04 INFO: [1 of 2] Running simulation for bts\n",
-      "100%|████████████████████████████████| 452949/452949 [00:13<00:00, 32636.61it/s]\n",
-      "9:59:19 INFO: [2 of 2] Running simulation for linear_ucb_0.0\n",
-      "100%|████████████████████████████████| 452949/452949 [00:36<00:00, 12432.60it/s]\n",
-      "9:59:56 INFO: Done in 51.41 seconds\n",
-      "9:59:56 INFO: Estimating rewards\n",
-      "9:59:56 INFO: Estimating reward confidence interval for logged feedback\n",
-      "9:59:56 INFO: [1 of 2] Estimating reward confidence interval for bts\n",
-      "10:00:57 INFO: [2 of 2] Estimating reward confidence interval for linear_ucb_0.0\n",
-      "10:02:00 INFO: Done in 124.57 seconds\n",
-      "10:02:00 INFO: Experiment finished in 183.74 seconds\n",
-      "10:02:00 INFO: Writing output to results ../experiments/obd_demo/results.pickle\n",
-      "10:02:03 INFO: Bye!\n"
+      "4:57:31 INFO: Building dataset\n",
+      "4:57:34 INFO: Building policies\n",
+      "4:57:34 INFO: Building estimators\n",
+      "4:57:34 INFO: Running experiment\n",
+      "4:57:34 INFO: Obtaining logged feedback\n",
+      "4:57:34 INFO: Done in 0.0 seconds\n",
+      "4:57:34 INFO: Fitting regression model\n",
+      "4:57:42 INFO: Done in 7.98 seconds\n",
+      "4:57:42 INFO: Running simulations\n",
+      "4:57:42 INFO: [1 of 2] Running simulation for bts\n",
+      "100%|████████████████████████████████| 452949/452949 [00:13<00:00, 33807.42it/s]\n",
+      "4:57:56 INFO: [2 of 2] Running simulation for linear_ucb_0.0\n",
+      "100%|████████████████████████████████| 452949/452949 [00:37<00:00, 12232.00it/s]\n",
+      "4:58:33 INFO: Done in 51.52 seconds\n",
+      "4:58:33 INFO: Estimating rewards\n",
+      "4:58:33 INFO: Estimating reward confidence interval for logged feedback\n",
+      "4:58:34 INFO: [1 of 3] Estimating reward confidence interval for logged\n",
+      "4:58:35 INFO: [2 of 3] Estimating rewards and reward confidence interval for bts\n",
+      "4:58:36 INFO: [3 of 3] Estimating rewards and reward confidence interval for linear_ucb_0.0\n",
+      "4:58:36 INFO: Done in 2.93 seconds\n",
+      "4:58:36 INFO: Experiment finished in 62.44 seconds\n",
+      "4:58:36 INFO: Writing output to results ../experiments/obd_demo/results.pickle\n",
+      "4:58:39 INFO: Bye!\n"
      ]
     }
    ],
@@ -139,7 +138,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "OBD experiments use off-policy estimators, so we just get a confidence interval for each policy as output:"
+    "For a quick summary of the outcomes, we have `reward_summary`:"
    ]
   },
   {
@@ -150,15 +149,15 @@
     {
      "data": {
       "text/plain": [
-       "{'logged': {'mean': 0.005124417980832279,\n",
-       "  '95.0% CI (lower)': 0.004902925053372455,\n",
-       "  '95.0% CI (upper)': 0.0053510991303656694},\n",
-       " 'bts': {'mean': 0.00541277551078753,\n",
-       "  '95.0% CI (lower)': 0.0054070022780304105,\n",
-       "  '95.0% CI (upper)': 0.005418496385973897},\n",
-       " 'linear_ucb_0.0': {'mean': 0.005327403099059197,\n",
-       "  '95.0% CI (lower)': 0.005321834978560733,\n",
-       "  '95.0% CI (upper)': 0.005333151384723679}}"
+       "{'logged': {'mean': 0.005126073796387674,\n",
+       "  '95.0% CI (lower)': 0.004940732841887277,\n",
+       "  '95.0% CI (upper)': 0.005346462846810568},\n",
+       " 'bts': {'mean': 0.0053872683460161105,\n",
+       "  '95.0% CI (lower)': 0.00538260774055602,\n",
+       "  '95.0% CI (upper)': 0.005392396666297001},\n",
+       " 'linear_ucb_0.0': {'mean': 0.005327208589589398,\n",
+       "  '95.0% CI (lower)': 0.005321954965442191,\n",
+       "  '95.0% CI (upper)': 0.005331800153828309}}"
       ]
      },
      "execution_count": 6,
@@ -167,7 +166,48 @@
     }
    ],
    "source": [
-    "obd_results.rewards"
+    "obd_results.reward_summary"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If we want to dive deeper into the rewards for each policy, we can access the full feedback dictionary for the _logged_ baseline data and partial feedback dictionaries for the _estimated_ policies:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Feedback for logged:\n",
+      "  n_rounds\n",
+      "  n_actions\n",
+      "  action\n",
+      "  position\n",
+      "  reward\n",
+      "  reward_test\n",
+      "  pscore\n",
+      "  context\n",
+      "  action_context\n",
+      "Feedback for bts:\n",
+      "  action\n",
+      "  reward\n",
+      "Feedback for linear_ucb_0.0:\n",
+      "  action\n",
+      "  reward\n"
+     ]
+    }
+   ],
+   "source": [
+    "for policy_name, feedback in obd_results.policy_feedback.items():\n",
+    "    print(f\"Feedback for {policy_name}:\")\n",
+    "    print(\"\\n\".join([f\"  {key}\" for key in feedback.keys()]))"
    ]
   },
   {
@@ -181,7 +221,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -197,34 +237,83 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Notice we include the random baseline _as a Random policy_. \n",
+    "\n",
+    "Also notice that extra parameters to pass to DeezerDataset's obtain_batch_bandit_feedback method (like `cascade`, `users_per_batch`, etc) can be included in `meta`."
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "10:02:07 INFO: Building dataset\n",
-      "10:02:24 INFO: Building policies\n",
-      "10:02:24 INFO: Running experiment\n",
-      "10:02:24 INFO: Obtaining random baseline feedback\n",
-      "Calculating click probabilities: 100%|█| 100000/100000 [00:16<00:00, 6157.31it/s\n",
-      "Generating feedback: 100%|███████████| 100000/100000 [00:03<00:00, 30689.28it/s]\n",
-      "10:02:45 INFO: Done in 20.93 seconds\n",
-      "10:02:45 INFO: Learning and obtaining policy feedback\n",
-      "10:02:45 INFO: [1 of 2] Learning and obtaining bts feedback\n",
-      "Simulating online learning: 100%|█████| 100000/100000 [00:30<00:00, 3305.76it/s]\n",
-      "10:03:16 INFO: [2 of 2] Learning and obtaining egreedy_0.1 feedback\n",
-      "Simulating online learning: 100%|█████| 100000/100000 [00:19<00:00, 5176.87it/s]\n",
-      "10:03:37 INFO: Done in 52.89 seconds\n",
-      "10:03:37 INFO: Estimating reward confidence interval for random baseline feedback\n",
-      "10:03:38 INFO: [1 of 2] Estimating reward confindence interval for bts feedback\n",
-      "10:03:39 INFO: [2 of 2] Estimating reward confindence interval for egreedy_0.1 feedback\n",
-      "10:03:40 INFO: Done in 2.09 seconds\n",
-      "10:03:40 INFO: Experiment finished in 75.91 seconds\n",
-      "10:03:40 INFO: Writing output to results ../experiments/deezer_demo/results.pickle\n",
-      "10:03:45 INFO: Bye!\n"
+      "- key: Random\n",
+      "  name: deezer_demo\n",
+      "  parameters:\n",
+      "    len_list: 12\n",
+      "    n_actions: 862\n",
+      "  meta:\n",
+      "    users_per_batch: 1000\n",
+      "- key: BernoulliTS\n",
+      "  name: deezer_demo\n",
+      "  parameters:\n",
+      "    batch_size: 1\n",
+      "    len_list: 12\n",
+      "    n_actions: 862\n",
+      "  meta:\n",
+      "    users_per_batch: 1000\n",
+      "- key: EpsilonGreedy\n",
+      "  name: deezer_demo\n",
+      "  parameters:\n",
+      "    batch_size: 1\n",
+      "    epsilon: 0.1\n",
+      "    len_list: 12\n",
+      "    n_actions: 862\n",
+      "    policy_name: \"egreedy_0.1\"\n",
+      "  meta:\n",
+      "    users_per_batch: 1000\n"
+     ]
+    }
+   ],
+   "source": [
+    "!cat ../experiments/deezer_demo/policy_spec.yaml"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "4:58:44 INFO: Building dataset\n",
+      "4:59:02 INFO: Building policies\n",
+      "4:59:02 INFO: Running experiment\n",
+      "4:59:02 INFO: Learning and obtaining policy feedback\n",
+      "4:59:02 INFO: [1 of 3] Learning and obtaining random feedback\n",
+      "Simulating online learning: 100%|█████| 100000/100000 [00:16<00:00, 5894.82it/s]\n",
+      "4:59:20 INFO: [2 of 3] Learning and obtaining bts feedback\n",
+      "Simulating online learning: 100%|█████| 100000/100000 [00:29<00:00, 3361.19it/s]\n",
+      "4:59:52 INFO: [3 of 3] Learning and obtaining egreedy_0.1 feedback\n",
+      "Simulating online learning: 100%|█████| 100000/100000 [00:17<00:00, 5759.49it/s]\n",
+      "5:00:11 INFO: Done in 68.68 seconds\n",
+      "5:00:11 INFO: Estimating reward confidence interval for random baseline feedback\n",
+      "5:00:11 INFO: [1 of 3] Estimating reward confindence interval for random feedback\n",
+      "5:00:11 INFO: [2 of 3] Estimating reward confindence interval for bts feedback\n",
+      "5:00:12 INFO: [3 of 3] Estimating reward confindence interval for egreedy_0.1 feedback\n",
+      "5:00:13 INFO: Done in 2.05 seconds\n",
+      "5:00:13 INFO: Experiment finished in 70.73 seconds\n",
+      "5:00:13 INFO: Writing output to results ../experiments/deezer_demo/results.pickle\n",
+      "5:00:18 INFO: Bye!\n"
      ]
     }
    ],
@@ -241,7 +330,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -253,47 +342,107 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We have the rewards intervals:"
+    "And here's the reward summary:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'random': {'mean': 0.02699252613151486,\n",
-       "  '95.0% CI (lower)': 0.026517594669501272,\n",
-       "  '95.0% CI (upper)': 0.027457833749215527},\n",
-       " 'bts': {'mean': 0.25231972103413514,\n",
-       "  '95.0% CI (lower)': 0.25093674231073093,\n",
-       "  '95.0% CI (upper)': 0.2537817037622252},\n",
-       " 'egreedy_0.1': {'mean': 0.06192555479448775,\n",
-       "  '95.0% CI (lower)': 0.06117091214775998,\n",
-       "  '95.0% CI (upper)': 0.06255089308380953}}"
+       "{'random': {'mean': 0.026948960972985,\n",
+       "  '95.0% CI (lower)': 0.02641966290614939,\n",
+       "  '95.0% CI (upper)': 0.02738962686410134},\n",
+       " 'bts': {'mean': 0.2506382996283325,\n",
+       "  '95.0% CI (lower)': 0.24929036553259037,\n",
+       "  '95.0% CI (upper)': 0.2520430705067717},\n",
+       " 'egreedy_0.1': {'mean': 0.05327880660531032,\n",
+       "  '95.0% CI (lower)': 0.052508679141554,\n",
+       "  '95.0% CI (upper)': 0.053848982936960416}}"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "deezer_results.rewards"
+    "deezer_results.reward_summary"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "But sice we learned our bandits online, we also have their rewards as they learned:"
+    "But sice we learned our bandits online, we have full feedback dictionaries for all of them:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Feedback for random:\n",
+      "  action\n",
+      "  reward\n",
+      "  position\n",
+      "  context\n",
+      "  action_context\n",
+      "  pscore\n",
+      "  n_rounds\n",
+      "  n_actions\n",
+      "  policy\n",
+      "  selected_actions\n",
+      "  users\n",
+      "  segments\n",
+      "  batches\n",
+      "Feedback for bts:\n",
+      "  action\n",
+      "  reward\n",
+      "  position\n",
+      "  context\n",
+      "  action_context\n",
+      "  pscore\n",
+      "  n_rounds\n",
+      "  n_actions\n",
+      "  policy\n",
+      "  selected_actions\n",
+      "  users\n",
+      "  segments\n",
+      "  batches\n",
+      "Feedback for egreedy_0.1:\n",
+      "  action\n",
+      "  reward\n",
+      "  position\n",
+      "  context\n",
+      "  action_context\n",
+      "  pscore\n",
+      "  n_rounds\n",
+      "  n_actions\n",
+      "  policy\n",
+      "  selected_actions\n",
+      "  users\n",
+      "  segments\n",
+      "  batches\n"
+     ]
+    }
+   ],
+   "source": [
+    "for policy_name, feedback in deezer_results.policy_feedback.items():\n",
+    "    print(f\"Feedback for {policy_name}:\")\n",
+    "    print(\"\\n\".join([f\"  {key}\" for key in feedback.keys()]))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -315,7 +464,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -324,13 +473,13 @@
        "Text(0, 0.5, 'cumulative rewards')"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAnAAAAFzCAYAAAC+bzSQAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8vihELAAAACXBIWXMAAAsTAAALEwEAmpwYAABNWElEQVR4nO3dd3zV9b3H8deX7EAGhB0Ie28MSxBBRcUFWG2ddVurtdr2tnWCe9U6UFuvt1rRat0CDqbiZINoEjIIMwkrEJKQPc73/vE7SETAIDn5nZPzfj4e53HO+Z3fOfkcDie8+U5jrUVEREREAkcztwsQERERkWOjACciIiISYBTgRERERAKMApyIiIhIgFGAExEREQkwCnAiIiIiASbU7QIaW+vWrW3Xrl3dLkNERETkJ61Zs2aPtbbNoceDLsB17dqV1atXu12GiIiIyE8yxmw93HF1oYqIiIgEGAU4ERERkQCjACciIiISYIJuDNzhVFdXk5ubS0VFhdulBKXIyEg6depEWFiY26WIiIgEBAU4IDc3l5iYGLp27Yoxxu1ygoq1lr1795Kbm0u3bt3cLkdERCQgqAsVqKioICEhQeHNBcYYEhIS1PopIiJyDBTgvBTe3KM/exERkWOjAOcHtmzZwsCBA390/KmnnqKsrMyFikRERMSfKcD5MQU4ERERORwFOD9RU1PDpZdeSr9+/bjggguYOXMm27dvZ+LEiUycOJHa2lquvPJKBg4cyKBBg3jyySfdLllERERcolmoh7j3gzTWby9u0Nfs3zGWGecOOOo5mZmZvPjii4wdO5arr76aqqoqOnbsyJIlS2jdujVr1qwhLy+P1NRUAAoLCxu0RhEREQkcaoHzE507d2bs2LEAXHbZZXz11Vc/eLx79+5s2rSJm2++mfnz5xMbG+tGmSIiIkGvsKyKT9J3uVqDWuAO8VMtZb5y6EzMQ++3bNmSb7/9lgULFvD888/z1ltv8dJLLzVmiSIiIkHN47G8vSaHR+dnUl5Vy/LbTyUu2p1F6NUC5ye2bdvGsmXLAHj99dcZN24cMTEx7N+/H4A9e/bg8Xj4xS9+wQMPPMDatWvdLFdERCSopOQWcf4/l/LXd1Po0aY57/72RNfCG6gFzm/06dOH5557jquvvpr+/fvz29/+lvDwcM4880w6duzIU089xVVXXYXH4wHg4YcfdrliERGRpq+wrIrHF2by2optJDSP4IlfDmHasETX1zA11lpXC2hsycnJdvXq1T84lp6eTr9+/VyqSECfgYiI+BdrLXPWbef+D9ezr6yKK07syh8m9SY2snFb3Ywxa6y1yYceVwuciIiISB1b9pRy1+xUvsrew9DO8bx6zSj6d/SvyYMKcCIiIiJAVY2HF77YyMxPs4kIacb9UwdyycgkQpr535aPCnAiIiIS9FZvKeD291LYsLuEswd1YPq5/WkXG+l2WUekACciIiJBq7iimkfnZfDaim0kxkfx0pXJnNK3ndtl/SQFOBEREQk61lrmp+5kxtw09pRUcs24bvxxUm+aRwRGNAqMKkVEREQaSE5BGfd+sJ7F6bvo3yGWf12RzOBO8W6XdUwU4ERERCQoVNbU8n9fbOLZJdkYDLdP7ss147oRGhJ4+xoEXsXS4Lp27cqePXuO+XmzZs2iV69e9OrVi1mzZh32nD//+c/07duXwYMHM23aNAoLC4+zWhERkWP35YZ8Jj/1JY8vzGJin7Z88qeT+c3JPQIyvIECXMCrqalx5ecWFBRw7733smLFClauXMm9997Lvn37fnTepEmTSE1N5bvvvqN3797aQUJERBrV7uIKbnp9LZe/uBKPtcy6eiT/vOwEOsZHuV3acVEX6qHm3QY7Uxr2NdsPgsmPHPWU//znP8ycOZOqqipGjRrFP/7xD15++WUeffRR4uPjGTJkCBERETz77LNceeWVREZG8s033zB27FhuuukmbrrpJvLz84mOjub//u//6Nu3L/n5+dxwww1s27YNgKeeeoqxY8eyd+9eLr74YvLy8hgzZgwHduOYPn06rVq14tZbbwXgzjvvpG3bttxyyy0/qnfBggVMmjSJVq1aAU5Qmz9/PhdffPEPzjv99NO/vz169Gjeeeedn/3HKCIiUl8ej+XN1Tk89HE6lTUe/jipN9eP705kWIjbpTUItcD5gfT0dN58802+/vpr1q1bR0hICK+99hr3338/y5cv5+uvvyYjI+MHz8nNzWXp0qU88cQTXH/99TzzzDOsWbOGxx9/nBtvvBGAW265hT/84Q+sWrWKd999l2uvvRaAe++9l3HjxpGWlsa0adO+D3hXX301r7zyCgAej4c33niDyy677LA15+Xl0blz5+/vd+rUiby8vKO+z5deeonJkyf/vD8kERGRetqYX8JF/7ec299LYUDHWBbcOp7fn9qryYQ3UAvcj/1ES5kvfPLJJ6xZs4YRI0YAUF5eztKlSzn55JO/b+G68MILycrK+v45F154ISEhIZSUlLB06VIuvPDC7x+rrKwEYPHixaxfv/7748XFxZSUlPDFF1/w3nvvAXD22WfTsmVLwBkLl5CQwDfffMOuXbsYNmwYCQkJDfIeH3zwQUJDQ7n00ksb5PVEREQOdWCSwsxPs4kMbcajvxjEL5M7u77xvC8owPkBay1XXHHFD8aHzZ49m/fff/+Iz2nevDngtJTFx8ezbt26H53j8XhYvnw5kZH1X0n62muv5eWXX2bnzp1cffXVRzwvMTGRzz777Pv7ubm5TJgw4bDnvvzyy3z44Yd88sknTfJLJCIi7vs8K59756axaU8pZw/qwIzz+tM2xn93Ujhe6kL1A6eeeirvvPMOu3fvBpwJAsOGDePzzz9n37591NTU8O677x72ubGxsXTr1o23334bcMLgt99+Czjjz5555pnvzz0Q8saPH8/rr78OwLx5834w+WDatGnMnz+fVatWccYZZxyx5jPOOIOFCxeyb98+9u3bx8KFCw97/vz583nssceYO3cu0dHRx/CnIiIi8tNy95Xxm1dXc8VLK7HAy1eN4LlLhzfp8AZqgfML/fv354EHHuD000/H4/EQFhbGc889xx133MHIkSNp1aoVffv2JS4u7rDPf+211/jtb3/LAw88QHV1NRdddBFDhgxh5syZ3HTTTQwePJiamhrGjx/P888/z4wZM7j44osZMGAAJ554IklJSd+/Vnh4OBMnTiQ+Pp6QkCOPFWjVqhV33333992+ByZAgNOKd8MNN5CcnMzvfvc7KisrmTRpEuBMZHj++ecb6o9ORESCVEW101363GfOmm5/PqMP157UjYjQpjPO7WjMgRmIwSI5OdmuXr36B8fS09Pp16+fSxUdWUlJCS1atKCmpoZp06Zx9dVXM23aNJ/+TI/Hw/Dhw3n77bfp1auXT39WXf76GYiIiP/5PCufGXNS2bK3jLMGtefOs/uTGODLghyJMWaNtTb50ONqgfNj99xzD4sXL6aiooLTTz+dqVOn+vTnrV+/nnPOOYdp06Y1angTERGpj+2F5dz/4Xrmpe6ke+vmvHL1SMb3buN2Wa5QgPNjjz/+eKP+vP79+7Np06YfHEtJSeHyyy//wbGIiAhWrFjRmKWJiEgQq6rx8OJXm5n5yQYsNui6Sw9HAU6OatCgQYed4SoiItIYVm0p4I73Utiwu4TT+7dj+rn96dRSk+IU4LystVriwiXBNg5TRER+WmFZFY/My+CNVTkkxkfx4hXJnNqvndtl+Q0FOCAyMpK9e/eSkJCgENfIrLXs3bv3mNaqExGRpstay/vf5PHgR+kUllfzm/HdueW0XkSHK7LUpT8NnG2gcnNzyc/Pd7uUoBQZGUmnTp3cLkNERFy2eU8pd76fwtKNexnaOZ5Xpw2if8dYt8vySwpwQFhYGN26dXO7DBERkaBUVePhfz/fyDNLsokIbcb9Uwdy6cgkmjVTr9iRKMCJiIiIa1ZuLuCO91PI3l3C2YM7MOOc/rSN1bCan6IAJyIiIo3u0EkK/75yBBP7tnW7rIChACciIiKNxlrL7HV5PPChM0nh+vHduVWTFI6Z/rRERESkUWzeU8pds1P4OluTFI6XApyIiIj4VGVNLf/7+SaerTNJ4ZKRSYRoksLPpgAnIiIiPrNs417unJ3CpvxSTVJoQApwIiIi0uAKSqt48KN03l2bS+dWUbx81Qgm9NEkhYaiACciIiINxuOxvLMml4fmpVNSUcONE3pw8ym9iAoP3o3nfUEBTkRERBrEd7mFTJ+TxrqcQkZ0bcmD0wbRu12M22U1SQpwIiIiclwKSqv42wJnTbeE5hE88cshTBuWqP3FfaiZL1/cGPMHY0yaMSbVGPNfY0ykMaabMWaFMSbbGPOmMSbce26E93629/GudV7ndu/xTGPMGXWOn+k9lm2Muc2X70VERER+qNZjeXXZFiY+/hlvrc7lmrHdWPI/J3P+8E4Kbz7msxY4Y0wi8Hugv7W23BjzFnARcBbwpLX2DWPM88A1wD+91/ustT2NMRcBjwK/Msb09z5vANARWGyM6e39Mc8Bk4BcYJUxZq61dr2v3pOIiIg4UvOKuPP9FL7NLeLEHgncc94AdZc2Il93oYYCUcaYaiAa2AGcAlzifXwWcA9OgJvivQ3wDvCsceL7FOANa20lsNkYkw2M9J6Xba3dBGCMecN7rgKciIiIj+yvqOaJRVnMWrqFVs0jmHnxMM4d3EEtbo3MZwHOWptnjHkc2AaUAwuBNUChtbbGe1oukOi9nQjkeJ9bY4wpAhK8x5fXeem6z8k55PgoH7wVERGRoGetZV7qTu79II3d+yu5fHQX/nR6H+KiwtwuLSj5sgu1JU6LWDegEHgbONNXP+8narkeuB4gKSnJjRJEREQCVl5hOdNnp/JJxm4GdIzlhcuTGdI53u2ygpovu1BPAzZba/MBjDHvAWOBeGNMqLcVrhOQ5z0/D+gM5BpjQoE4YG+d4wfUfc6Rjv+AtfYF4AWA5ORke/xvTUREpOmr9VhmLd3C4wszsRbuOrsfV57YldAQn86BlHrwZYDbBow2xkTjdKGeCqwGlgAXAG8AVwBzvOfP9d5f5n38U2utNcbMBV43xjyBM4mhF7ASMEAvY0w3nOB2EQfH1omIiMhxSNtexO3vpfBdbhET+rThgakD6dQy2u2yxMuXY+BWGGPeAdYCNcA3OK1gHwFvGGMe8B570fuUF4FXvZMUCnACGdbaNO8M1vXe17nJWlsLYIz5HbAACAFestam+er9iIiIBIPyqlqeWpzFv77aTMvoMJ65eBjnaJKC3zHWBlePYnJysl29erXbZYiIiPidz7PyuWt2CjkF5fwquTO3n9WX+Ohwt8sKasaYNdba5EOPaycGERGRILenpJIHPlzP7HXb6d6mOW9cP5rR3RPcLkuOQgFOREQkSNXdeL60soZbTu3FjRN7EBGqjef9nQKciIhIEMrcuZ+7Zqewass+RnRtycPnD6JnW+2kECgU4ERERIJIWVUNT3+ygRe/3ExMZCh/u2AwF5ygvUsDjQKciIhIkFi8fhcz5qaRV+hMUrhtcl9aNtckhUCkACciItLE5RSUce8H61mcvove7Vrw9g1jGNG1ldtlyXFQgBMREWmiqmo8/OurTcz8ZAMGw+2T+3L1uG6EaSeFgKcAJyIi0gQt27iXu+ekkr27hDMHtGf6uf3pGB/ldlnSQBTgREREmpDdxRU8+HE6c9Ztp3OrKP595Qgm9m3rdlnSwBTgREREmoCaWg+vLNvKk4uyqKzx8PtTe3HjhB5EhmlNt6ZIAU5ERCTArd5SwF2zU8nYuZ+Te7fh3vMG0LV1c7fLEh9SgBMREQlQu/dX8Mi8DN5bm0fHuEiev2w4ZwxorzXdgoACnIiISICprvUwa+kWnlq8gcqaWm6c0IPfndKT6HD9sx4s9EmLiIgEkGUb9zJjbipZu0o4uXcbZpzbn+5tWrhdljQyBTgREZEAUFhWxUMfp/PW6lw6tYzihctPYFL/duouDVIKcCIiIn7MWstHKTu4Z24a+8qqueHkHtxyai+iwjW7NJgpwImIiPip7YXlTJ+TyuL03QxKjGPW1SMZ0DHO7bLEDyjAiYiI+JmaWg8vL93Ck4uy8Fi46+x+XHliV0K1BZZ4KcCJiIj4kTVb93HX7FTSdxQzsU8b7psykM6tot0uS/yMApyIiIgfKCyr4tH5Gfx3ZQ4dtKab/AQFOBERERd5PJa31+Tw6PxMisqrue6kbtx6Wm+aR+ifaDky/e0QERFxybc5hUyfk8q3uUUkd2nJ/VMH0q9DrNtlSQBQgBMREWlkBaVV/G1BBm+syqF1iwie/NUQpg5NVHep1JsCnIiISCPxeCz/XbWNx+ZnUlpZw7XjuvH7U3sRExnmdmkSYBTgREREGkHa9iLufD+VdTmFjOmewH1TBtCrXYzbZUmAUoATERHxoZLKGp5YmMXLSzfTqnk4T/1qKFOGdlR3qRwXBTgREREfsNYyL3Un932wnl37K7hkZBJ/OaMvcdHqLpXjpwAnIiLSwLbuLWX6nDQ+z8qnf4dY/nnZcIYltXS7LGlCFOBEREQaSGVNLS98volnl2QT2sww/Zz+/HpMF22BJQ1OAU5ERKQBLN24h7tmp7Ipv5SzB3Xg7nP60z4u0u2ypIlSgBMRETkOe0sqefDjdN5bm0fnVlH8+6oRTOzT1u2ypIlTgBMREfkZDmyB9fC8DEoqarhxQg9uPqUXUeEhbpcmQUABTkRE5Bht2LWfO99PZeWWAkZ0bcmD0wbRW2u6SSNSgBMREamniupanvl0Ay98sYnmEaE8+otBXHhCZ5o105pu0rgU4EREROrh86x87p6dyraCMs4fnsidZ/UjoUWE22VJkFKAExEROYrdxRXc9+F6PvxuB91bN+f160ZxYo/WbpclQU4BTkRE5DCqaz3MWrqFpxZvoKrWwx9O680NE7oTEapJCuI+BTgREZFDfJ29hxlz08jeXcKEPm2Yce4AurVu7nZZIt9TgBMREfHKKyznwY/W83HKTpJaRfOvXydzar+22nhe/I4CnIiIBD2Px/LKsi08tiATj7X8aVJvrhvfncgwdZeKf1KAExGRoLYpv4S/vvsdq7bs4+TebXhw2kA6tYx2uyyRo1KAExGRoFRT6+HFrzbzxKIsIkKb8fiFQ/jF8ER1l0pAUIATEZGgk5JbxJ2zU/gut4gzBrTj/ikDaRurjeclcCjAiYhI0Cgqr+aJhZm8unwrrZpH8Owlwzh7UAe1uknAUYATEZEmz1rLnHXbeeCjdApKK/n1mK788fTexEaGuV2ayM+iACciIk1a9u4Sps9JZenGvQzpFMe/rxzBoE5xbpclclwU4EREpEkqr6rl2SXOxvNRYSHcP3Ugl4xMIkQbz0sToAAnIiJNzifpu5gxN43cfeWcPzyR2yf3o02MNp6XpkMBTkREmowdReXMmJPGwvW76NW2BW9cP5rR3RPcLkukwSnAiYhIwPN4LP9dtY2HP86gxuPhtsl9uXpsN8JDm7ldmohPKMCJiEhA27KnlNve+47lmwo4sUcCj5w/mKQE7aQgTZsCnIiIBKSaWg8vfb2Zvy/MIjykGY+cP4hfjeisNd0kKCjAiYhIwFm7bR93vZ/K+h3FnNavHQ9MHUj7OO2kIMFDAU5ERAJGQWkVj87L4M3VObSPjeS5S4Zz1qD2anWToKMAJyIifs/jsby1OodH5mdQUlHD9eO78/tTe9EiQv+MSXA6puk5xphmxpjYYzg/3hjzjjEmwxiTbowZY4xpZYxZZIzZ4L1u6T3XGGNmGmOyjTHfGWOG13mdK7znbzDGXFHn+AnGmBTvc2Ya/RdMRKTJWZdTyLR/LuW291Lo3S6Gj285iTvO6qfwJkHtJwOcMeZ1Y0ysMaY5kAqsN8b8uZ6v/zQw31rbFxgCpAO3AZ9Ya3sBn3jvA0wGenkv1wP/9P78VsAMYBQwEphxIPR5z7muzvPOrGddIiLi5/aUVPKXd75l6nNfs72wnCd+OYQ3rx9N73Yxbpcm4rr6/Pelv7W22BhzKTAPJ3CtAf52tCcZY+KA8cCVANbaKqDKGDMFmOA9bRbwGfBXYArwirXWAsu9rXcdvOcustYWeF93EXCmMeYzINZau9x7/BVgqrdGEREJUNW1Hl5dtpUnF2dRXlXL9eO7c/MpPYnRxvMi36tPgAszxoThhKNnrbXVxhhbj+d1A/KBfxtjhuCEvluAdtbaHd5zdgLtvLcTgZw6z8/1Hjva8dzDHBcRkQC1ZmsBd76fSsbO/ZzUqzUzzh1Az7Yt3C5LxO/UJ8D9L7AF+Bb4whjTBSiu52sPB2621q4wxjzNwe5SAKy1tp5h8LgYY67H6ZYlKSnJ1z9ORESOUWFZFY/Oz+S/K7fRIS6S5y87gTMGtNPsUpEj+MkAZ62dCcysc2irMWZiPV47F8i11q7w3n8HJ8DtMsZ0sNbu8HaR7vY+ngd0rvP8Tt5jeRzscj1w/DPv8U6HOf9w7+EF4AWA5ORknwdGERGpH2sts9fl8cCH6RSWV3PtuG78YVJvmmuCgshRHfEbYoz5408894mjPWit3WmMyTHG9LHWZgKnAuu9lyuAR7zXc7xPmQv8zhjzBs6EhSJvyFsAPFRn4sLpwO3W2gJjTLExZjSwAvg18MxP1CwiIn5i855S7pqdwtfZexnSOZ5Xpg1kQMc4t8sSCQhH+y/OgWk+fYAROAEL4FxgZT1f/2bgNWNMOLAJuApn5utbxphrgK3AL73nfgycBWQDZd5z8Qa1+4FV3vPuOzChAbgReBmIwpm8oAkMIiJ+rqrGwwtfbGTmp9lEhDTj/ikDuGRUF0KaqbtUpL6MM+nzKCcY8wVwtrV2v/d+DPCRtXZ8I9TX4JKTk+3q1avdLkNEJCit2VrA7e+lkLWrhLMGtWfGuQNoF6stsESOxBizxlqbfOjx+gwyaAdU1blfxcGZoyIiIj+psKyKxxZk8vqKbXSMi+TFK5I5tZ/+KRH5ueoT4F4BVhpj3vfen4rTbSkiInJUHo/lnTW5PDI/g8KyKq4Z140/apKCyHE76jfIuzXVKzhjy07yHr7KWvuNrwsTEZHAlra9iOlz0lizdR/JXVpy35RR9O9Y790YReQojhrgvOu0fWytHQSsbaSaREQkgBWVV/PkoixeWbaFltHh/O2CwfxieCeaaZKCSIOpTxv2WmPMCGvtqp8+VUREgpXHY3l3bS6Pzs9gb2kVl4xM4i9n9CUuWltgiTS0+gS4UcClxpitQClgcBrnBvu0MhERCRipeUVMn5PK2m2FDO0cz7+vHMmgTlrTTcRX6hPgzvB5FSIiEpCKyqt5fEEmr63YSsvocB67YDAXqLtUxOfqs5XWVgBjTFtAi/WIiAjWWuan7mTG3DT2lFRy+egu/HFSH3WXijSSnwxwxpjzgL8DHXH2Le0CpAMDfFuaiIj4ox1F5Uyfk8ai9bvo3yGWf12RzOBO8W6XJRJU6tOFej8wGlhsrR3m3cj+Mt+WJSIi/sbjsfxnxVYem59JjcfD7ZP7cvW4boSFNHO7NJGgU58AV22t3WuMaWaMaWatXWKMecrXhYmIiP/YsGs/t72Xwpqt+xjXszUPThtIl4TmbpclErTqE+AKjTEtgC9wNqbfjTMbVUREmrjKmlr+sWQj//gsmxYRofz9wiGcPzwRZ513EXFLfQLcFKAc+ANwKRAH3OfLokRExH2rtjgbz2fvLmHq0I7cfU5/ElpEuF2WiFC/AHcR8IW1dgMwy8f1iIiIy/aVVvHYggz+uzKHxPgoXr5qBBP6tHW7LBGpoz4BLgn4X2NMN2A1Tlfql9badb4sTEREGpfHY3lnbS6PzMugqLyaa8d14w/aeF7EL9VnHbgZAMaYKOA64M/AU0CITysTEZFGk76jmLtnp7J66z5O6NKSB6YOpF8HbTwv4q/qsw7cXcBYoAXwDfA/wJc+rktERBpBcUU1Ty3awKxlW4iNDNVOCiIBoj7t4ucDNcBHwOfAMmttpU+rEhERn/J4LO+syeWxBc7G8xeNSOIvZ/ShZfNwt0sTkXqoTxfqcGNMLE4r3CTgBWPMbmvtOJ9XJyIiDe6bbfu4Z24a3+YWcUKXlrx81UgGJmrjeZFAUp8u1IHAScDJQDKQg7pQRUQCzr7SKh6Zl8Gbq3NoGxPBk78awtShWtNNJBDVpwv1EZzANhNYZa2t9m1JIiLSkKy1vLs2j4c+Tqe4vJrfjO/Ozaf2ooVml4oErPp0oZ7jnYGapPAmIhJYsneXcOf7KazYXMDwpHgeOn8QfdtrdqlIoKtPF+q5wONAONDNGDMUuM9ae56PaxMRkZ+pvKqW55Zk879fbCQqLISHzx/Er5I7a3apSBNRn/bze4CRwGcA1tp13kV9RUTEz1hrWZC2k/s/TCevsJxpwxK58+x+tNYWWCJNSn0CXLW1tuiQQa7WR/WIiMjPtCm/hBlz0/hywx76to/hrd+MYWS3Vm6XJSI+UJ8Al2aMuQQIMcb0An4PLPVtWSIiUl/lVbU8u2QDL3yxicjQEKaf059fj+lCaEgzt0sTER+pT4C7GbgTqAReBxYAD/iyKBERqZ8lGbu5e04qufvKOX94IrdN7kvbmEi3yxIRHztqgDPGhAAfWWsn4oQ4ERHxAzuKyrnvg/XMS91Jz7YteOP60YzunuB2WSLSSI4a4Ky1tcYYjzEmzlpb1FhFiYjI4dXUepi1bCtPLMykxmP58xl9uO6k7oSHqrtUJJjUpwu1BEgxxiwCSg8ctNb+3mdViYjIj6TkFnH7+9+RmlfMyb3bcP+UgSQlRLtdloi4oD4B7j3vRUREXFBaWcPfF2bx8tLNJLSI4NlLhnH2oA7aAkskiNVnJ4ZZjVGIiIj82OL1u5g+J5XtRRVcOiqJv5zZl7ioMLfLEhGXaSM8ERE/lFdYzr1z01i4fhd92sXw7iXDOKGL1nQTEYcCnIiIH6mu9fDvrzfz1OINeKzlr2f25Zpx3TRJQUR+oN4BzhgTba0t82UxIiLBbPWWAu58P5XMXfs5rV9bZpw7gM6tNElBRH6sPpvZnwj8C2gBJBljhgC/sdbe6OviRESCQXFFNY/My+D1FdvoGBfJC5efwOkD2rtdloj4sfq0wD0JnAHMBbDWfmuMGe/TqkREgsT81J1Mn5PKnpJKrh3XjT9M6k3zCI1uEZGjq9dvCWttziHT1Wt9U46ISHDYVVzBjDlpzE/bSb8OsfzrimQGd4p3uywRCRD1CXA53m5Ua4wJA24B0n1blohI0+TxWF5fuY1H52dQVePhr2f25dqTuhGmjedF5BjUJ8DdADwNJAJ5wELgJl8WJSLSFGXsLOaO91JYu62QE3sk8NC0QXRt3dztskQkANUnwBlr7aU+r0REpIkqr6pl5qcb+L8vNhEbFcYTvxzCtGGJ2klBRH62+gS4r40xW4A3gXettYU+rUhEpAn5LHM3d89JJaegnF8md+L2yf1o2Tzc7bJEJMDVZyut3saYkcBFwJ3GmPXAG9ba//i8OhGRALWruIL7PljPRyk76N6mOW9cP5rR3RPcLktEmoj6zkJdCaw0xjwEPAHMAhTgREQOUeuxvLpsC48vzKK61sP/nN6b68Z3JyI0xO3SRKQJqc9CvrHANJwWuB7A+8BIH9clIhJwvs0p5K7ZqaTkFXFSr9Y8MHUgXRI0SUFEGl59WuC+BWYD91lrl/m2HBGRwLOvtIrHFmTyxqpttG4RwTMXD+OcwR00SUFEfKY+Aa67tdb6vBIRkQBT67H8d+U2Hl+Yyf6KGq4e241bT+tFTGSY26WJSBN3xABnjHnKWnsrMNcY86MAZ609z5eFiYj4s2+27WP6nDRS8ooY1a0V900ZSJ/2MW6XJSJB4mgtcK96rx9vjEJERAJB/v5KHpufwdtrcmkXG8HMi4dxrrpLRaSRHTHAWWvXeG8OtdY+XfcxY8wtwOe+LExExJ9U13p4ddlWnlyURUVNLb85uTs3n9KLFtp4XkRcUJ/fPFfgbKVV15WHOSYi0iQt27iXGXNTydpVwvjebZhxbn96tGnhdlkiEsSONgbuYuASoJsxZm6dh2KAAl8XJiLitqKyah76OJ03V+fQuVUUL1x+ApP6t1N3qYi47mgtcEuBHUBr4O91ju8HvvNlUSIibpufuoO756RRUFrFDSf34NbTehEZpsV4RcQ/HG0M3FZgKzCm8coREXHX7uIKps9JY37aTgZ0jOXfV45gYGKc22WJiPxAfXZiGA08A/QDwoEQoNRaG+vj2kREGk11rYdZS7fw9OINVNV6+OuZfbn2pG6EhTRzuzQRkR+pzySGZ3G20XobSAZ+DfT2ZVEiIo3pi6x87v0gjY35pZzcuw33nDeAbq21BZaI+K96/dfSWpsNhFhra621/wbOrO8PMMaEGGO+McZ86L3fzRizwhiTbYx50xgT7j0e4b2f7X28a53XuN17PNMYc0ad42d6j2UbY26rb00iIgBb95Zy7azV/PqlldR4LC9ekczLV41QeBMRv1efFrgyb8haZ4x5DGdiw7H0KdwCpAMHulwfBZ601r5hjHkeuAb4p/d6n7W2pzHmIu95vzLG9MdpARwAdAQWG2MOtAA+B0wCcoFVxpi51tr1x1CbiAShiupa/rEkm+c/30RYiOGvZ/bl6nFdiQjVJAURCQz1CWKX44x7+x1QCnQGflGfFzfGdALOBv7lvW+AU4B3vKfMAqZ6b0/x3sf7+Kne86cAb1hrK621m4FsYKT3km2t3WStrQLe8J4rInJEi9fv4rQnPmfmp9lMHtSeT/9nAr+d0EPhTUQCyk+2wHlnowKUA/ce4+s/BfwFZ+04gASg0Fpb472fCyR6bycCOd6fWWOMKfKenwgsr/OadZ+Tc8jxUYcrwhhzPXA9QFJS0jG+BRFpCnIKyrj3gzQWp++mV9sW/Pe60YzpkeB2WSIiP8vRFvJNAX60if0B1trBR3thY8w5wG5r7RpjzISfW2BDsNa+ALwAkJycfMT3JCJNT2VNLS98volnl2QT0sxwx1l9uWqsZpeKSGA7WgvcOcf52mOB84wxZwGROGPgngbijTGh3la4TkCe9/w8nO7ZXGNMKBAH7K1z/IC6zznScRERlmbv4a45qWzKL+WsQe25+5z+dIiLcrssEZHj9lML+f5s1trbgdsBvC1w/2OtvdQY8zZwAc6YtSuAOd6nzPXeX+Z9/FNrrfVu4/W6MeYJnEkMvYCVgAF6GWO64QS3i3C2/hKRIJe/v5IHP1rP7HXbSWoVzctXjWBCn7ZulyUi0mDqs5Dvfg52pYYDYRzfQr5/Bd4wxjwAfAO86D3+IvCqMSYbZ6/ViwCstWnGmLeA9UANcJO1ttZb2++ABTiTLF6y1qb9zJpEpAnweCxvrMrh4XnpVFTX8vtTenLjxJ7aAktEmhxjbf2HhNWZFTraWhuQ664lJyfb1atXu12GiDSw7N37uf29FFZt2cfo7q14cNogerRp4XZZIiLHxRizxlqbfOjx+qwD9z3rpL3ZxpgZQEAGOBFpWipravnnZxv5x5KNRIWH8NgFg7nwhE44/98UEWma6tOFen6du81wttOq8FlFIiL1tHJzAXe8n0L27hKmDO3I3ef0p3WLCLfLEhHxufq0wJ1b53YNsAUtmCsiLtpbUsnD8zJ4Z00uifFR/PuqEUzUJAURCSL1Wcj3qsYoRETkp3g8lrdW5/DI/AxKKmq4cUIPbj6lF1HhmqQgIsGlPl2o3YCbga51z7fWnue7skREfih9RzF3zU5lzdZ9jOzWigenDqRXu5iffqKISBNUny7U2ThLfHwAeHxajYjIIUoqa3hqURb/XrqFuKgwHr9wCL8YnqhJCiIS1OoT4CqstTN9XomISB3WWj5O2cl9H6axe38lF49M4i9n9CE+Otzt0kREXFefAPe0d9mQhUDlgYPW2rU+q0pEgtrmPaVMn5PKlxv2MKBjLM9fdgLDklq6XZaIiN+oT4AbBFwOnMLBLlTrvS8i0mDKqmp49tNs/vXlZiJCm3HflAFcOqoLIc3UXSoiUld9AtyFQHdrbZWvixGR4GSt5cPvdvDQx+nsKKrgF8M78dfJfWgbE+l2aSIifqk+AS4ViAd2+7YUEQlGmTv3M2NuKss3FTCgYyzPXjKME7q0crssERG/Vp8AFw9kGGNW8cMxcFpGRER+tsKyKp5clMV/VmwjJjKUB6cN5KIRSeouFRGph/oEuBk+r0JEgkZNrYfXV27jiUVZFJdXc9noLvzhtN60bK7ZpSIi9VWfnRg+b4xCRKTp+2rDHu77MI2sXSWc2COB6ef2p2/7WLfLEhEJOPXZiWE/zqxTgHAgDCi11uq3rojUy46ich74MJ2PUnaQ1Cqa/738BE7v306L8YqI/Ez1aYH7fq8a4/y2nQKM9mVRItI0VNV4eOnrzcz8ZAO1HsufJvXmuvHdiQzT3qUiIsejPmPgvmettcBs78K+t/mmJBFpCpZm72H63DSyd5cwqX87pp/Tn86tot0uS0SkSahPF+r5de42A5KBCp9VJCIBbVdxBQ98lM4H324nqVU0L12ZzCl927ldlohIk1KfFrhz69yuAbbgdKOKiHyvutbDrKVbeHJRFtUeyy2n9uK3E3qou1RExAfqMwbuqsYoREQC16otBdw9O5WMnfuZ2KcN95w3gC4Jzd0uS0SkyapPF+os4BZrbaH3fkvg79baq31cm4j4uT0llTz8cQbvrs0lMT5Ks0tFRBpJfbpQBx8IbwDW2n3GmGG+K0lE/F2tx/Lfldt4bH4G5dW1/HZCD24+pSfR4cc0L0pERH6m+vy2bWaMaWmt3QdgjGlVz+eJSBOUklvEXXNS+TankDHdE7h/6gB6to356SeKiEiDqU8Q+zuwzBjztvf+hcCDvitJRPxRYVkVf1+YxWsrtpLQIoKnLxrKeUM6qrtURMQF9ZnE8IoxZjVwivfQ+dba9b4tS0T8hcdjeWt1Do8tyKSwrIpfj+nKH0/vTWxkmNuliYgErXp1hXoDm0KbSJD5LreQu+ek8W1OISO7tuLeKQPo10G76ImIuE1j2UTkRwpKq/jbggzeWJVD6xYRPPWroUwZqu5SERF/oQAnIt+r9VheX7mNxxdkUlJZw9Vju3Hrab2IUXepiIhfUYATEQDWbC3g7tlprN9RzJjuCdw7ZQC922l2qYiIP1KAEwly+fsreWSesxhvh7hInr1kGGcP6qDuUhERP6YAJxKkaj2W11Zs5W8LMqmoruWGk53FeJtH6NeCiIi/029qkSC0dts+7p6dStr2Ysb2TODe8wbSs20Lt8sSEZF6UoATCSJF5dU8Mi+D/67cRrvYCHWXiogEKAU4kSBgrWVe6k5mzE1jb0kl147rxq2TetNC3aUiIgFJv71FmridRRXcPSeVRet3MaBjLP++cgQDE+PcLktERI6DApxIE3VgksJj8zOp8Xi4fXJfrhnXjdCQZm6XJiIix0kBTqQJWpdTyN2zU0nJK2Jcz9Y8NG0QSQnRbpclIiINRAFOpAkpLKvi0fmZvLFqG21aRDDz4mGcO1iTFEREmhoFOJEmwOOxvLMml0fmZ1BUXq0tsEREfMVa2PEt7EqFYZe5VoYCnEiAW72lgHs/WE9KXhHJXVpy/9SB9OsQ63ZZIiJNh8cDuasgfa5zKdwGoZEwYBqEN3elJAU4kQCVV1jOI/My+ODb7bSPjeTpi4Zy3pCO6i4VEWkItTWw9WtI/wAyPoT9O6BZGPSYCOP/An3Oci28gQKcSMCpqK7l+c838vznG7EWfn9qL244uTvR4fo6i4gcl+oK2LTECW2ZH0P5PgiNgp6nQv8p0PsMiPSPZZj0G18kgHySvot7Pkgjp6Ccswd34PbJfenUUrNLRUR+tv07IWuBc9m0BKrLICIO+pwJ/c6FHqdCuP/9nlWAEwkAOQVl3PtBGovTd9OzbQtev24UJ/Zo7XZZIiKBac8GSHsfMj6CHeucY3GdYegl0GcydB0PoeGulvhTFOBE/FhFdS0vfLGJ55ZkE9LMcPvkvlw1thvhoVqMV0TkmOzbCmnvQep7sPM7wECnEXDqdOh9JrTtDwE0hlgBTsRPfZGVz4y5aWzeU8rZgzpw1zn96BAX5XZZIiKBoboCclbA5i+crtG8Nc7xxGQ442EYMBViO7pa4vFQgBPxMzuLKrj/w/V8lLKDrgnRvHL1SMb3buN2WSIi/s1ayM9wJh9s+twJbzUVYEIg8QQ47R5n2Y+WXd2utEEowIn4iZpaDy8v3cKTi7Ko8Vj+OKk314/vTmRYiNuliYj4pwPrs2V86FwKNjnH2w2E5Gug+8mQNAYim97amApwIn5g1ZYC7p6dSsbO/Uzs04Z7zxuovUtFRA6ncj9sXAIbFkDWQijd7azP1m08jPmdsz5bbAe3q/Q5BTgRF+0pqeSReRm8syaXjnGRPH/ZCZwxoJ0W4xUROcBaZ9Zo9mLImg9bl4Kn2lnqo+ep0Pds6DXJb9ZnaywKcCIuqPVY/rtyG4/Nz6CsqpbfTujBzaf01GK8IiIAZQWw6TPY+KnT2lac6xxv3QdG/9ZZULfzKAgJ3v2e9a+FSCNLyS3irtkpfJtbxJjuCdw/dQA928a4XZaIiLuKdzj7jKbNhm3LAOu0snU/Gcb/CXqc0mQmIDQEBTiRRlJUXs3jCzL5z4qttG4Rob1LRSS4eTzOpIPsxbB+NmxbDlhnPbaT/wo9T4OOwyBEUeVw9Kci4mPWWt7/Jo+HPk6noLSKK8Z05Y+n9yY2Mnib/kUkyFgL+7Y4a7Ft/wZ2fOtcKoudx9sOgIl3QP+p0Ka3m5UGDAU4ER9K31HMjDlprNxSwNDO8bx81UgGJgbXQFsRCUIeD+zJhK1fw9ZlzsSD/dudx0IioP1AGPxL6DAUkkZD616ulhuIfBbgjDGdgVeAdoAFXrDWPm2MaQW8CXQFtgC/tNbuM04/0tPAWUAZcKW1dq33ta4A7vK+9APW2lne4ycALwNRwMfALdZa66v3JFJfReXVPLkoi1eXbyU2MpSHzx/Er5I706yZuktFpIkqL3QmHWxY6HSLluY7x2M6QJcTnfXYOo90ukiDePJBQ/FlC1wN8Cdr7VpjTAywxhizCLgS+MRa+4gx5jbgNuCvwGSgl/cyCvgnMMob+GYAyThBcI0xZq61dp/3nOuAFTgB7kxgng/fk8hReTyWd9bm8ui8DPaVVXHpqC786fTexEf796bIIiI/S36Ws/PBhoXOGDZbC1EtnfFr3Sc4wa1lt4DaYzRQ+CzAWWt3ADu8t/cbY9KBRGAKMMF72izgM5wANwV4xduCttwYE2+M6eA9d5G1tgDAGwLPNMZ8BsRaa5d7j78CTEUBTlzyXW4hM+am8c22QoYnxTPranWXikgT46mFnJWQ+RFkzoO92c7xdoNg3K3Q6wzolAzNtIOMrzXKGDhjTFdgGE5LWTtvuAPYidPFCk64y6nztFzvsaMdzz3M8cP9/OuB6wGSkpKO452I/Njekkr+tiCTN1fnkNA8gscvHML5wxLVXSoiTUNlibMZfOY8ZyHdsr3enQ9OglE3QJ/JENfJ7SqDjs8DnDGmBfAucKu1trjukgnWWmuM8fmYNWvtC8ALAMnJyRojJw2iptbDf5Zv5YlFWZRV1XLN2G78/rReml0qIoGveLsT1jLnORvD11Y6Ox30Ot3ZqqrnqUG384G/8WmAM8aE4YS316y173kP7zLGdLDW7vB2ke72Hs8DOtd5eifvsTwOdrkeOP6Z93inw5wv4lPWWj7PyufhjzPI3LWfcT1bc895/bUYr4gELo8HdqxzQlvWfGeJD4D4LjDiGqeVLWmMJh/4EV/OQjXAi0C6tfaJOg/NBa4AHvFez6lz/HfGmDdwJjEUeUPeAuAhY0xL73mnA7dbawuMMcXGmNE4XbO/Bp7x1fsRAUjbXsTDH2fwVfYeuiRE8/xlwzljQHstxisigaeswOkazf7EmTVasgtMM2eLqtPuccazte2nCQh+ypctcGOBy4EUY8w677E7cILbW8aYa4CtwC+9j32Ms4RINs4yIlcBeIPa/cAq73n3HZjQANzIwWVE5qEJDOIjO4rK+fvCLN5dm0tcVBjTz+nPZaO7EB7azO3SRETqx+NxFtE9sMzH9rVgPRAZ72xT1ftMZ/Zo8wS3K5V6MMG2bFpycrJdvXq122VIgKioruWFLzbxj8+y8XjgqrFduXFiT+Ki1I0gIgGgcr+zGXzWAtiwwLs2m3FmivY87eB2VZo16reMMWustcmHHtdODCKHYa1lXupOHvwonbzCcs4e1IHbJvelc6tot0sTETmymkrIXQ1bvoItXzprs3mqnU3he512sJUtupXblcpxUoATOUTGzmLunbueZZv20rd9DP+9bjRjeqhLQUT8kLWQn+ksprvpM2eNtppywED7QTD6Bie0dR6lCQhNjAKciFdxhbP91SvLthITGcr9UwZw8cgkQkM0zk1E/EhttdOyljnPCW77NjvH2w2EE6501mdLGqNWtiZOAU6CnrWW97/J46GPM9hbWsklI5P4n9P70LK5tr8SET9RstuZeLBhobPfaEWRsyl895Nh7O+dVrbYjm5XKY1IAU6CWvqOYqbPSWXVln0M6RzPS1cmM7hTvNtliUgw83igcCvsTHHWZtu4xJkxCtCiHfQ711nio8cpENHC1VLFPQpwEpT2V1Tz1OINvLx0C7GRoTxy/iB+mdxZ21+JSOOrrnAmHGQvdhbQ3ZkKVfudx0wz6DQCTrnL2QWh/WCtyyaAApwEGWstH363g/s/XE9+SSUXjUjiL2eou1REGlnxdqc7NGuBM/mgugxCo6DDEBhykTMBof0gZyHdsCi3qxU/pAAnQWNjfgkz5qTxVfYeBibG8sKvkxnaOd7tskQkGFgLu9Mh8yPI+MhZUBcgLgmGXuqMYes6DsIi3a1TAoYCnDR5+yuqeXZJNv/+agsRYc24b8oALh3VhRB1l4qIL1WVQc5yZ6uqjI8OzhZNTIZTp0PvydqqSn42BThpsmo9lrdX5/D4wkz2lFRxwQmd+OuZfWkTE+F2aSLSFFWXw/Z1sPkL2Py5syabpxpCwqHbeO9s0ckQ28HtSqUJUICTJmnZxr3c/+F61u8oJrlLS166coRml4pIwynJh7zVsCsVdqU5l73Zzt6iGGcs2+jfOst8dB6t2aLS4BTgpEnZtreMhz5OZ37aThLjo3j2kmGcPagDRl0UInI8PB7Y8Q1sWORMPNj+DeDdS7xlV2cR3QHTnFmiXU7UIrricwpw0iSUVNbwjyXZ/OvLzYSGGP40qTfXje9OZJg2aBaRn8Fa2LMBtn7tXDYugbI9fL8R/MQ7nG7RdgMgIsbtaiUIKcBJQPN4LO+uzeWxBZnk76/k/GGJ/OXMvrSP00wuETkGJfmwO81Zgy1nBWxd6g1sOIvn9pjorMPW41Rorr2RxX0KcBKwlm/ay4MfpZOSV8SwpHheuPwEhiW1dLssEfF3tTWQu9JZh237Omf8Wunug4/HJUGvSU5XaJex0Kq7ZoqK31GAk4CzKb+Eh+dlsGj9LjrGRfLUr4Zy3pCO2kVBRI6sotjZQzRznhPcygugWZjTBdrrdGjX37nddgC0aON2tSI/SQFOAsa+0iqe/mQD/1m+lciwEP58Rh+uGddN49xEglV1hTPzs2wPlO2FsgLnunQPlOY7l5LdTutaRZHznKiWzj6ifSY7e4lGxrr7HkR+JgU48XsV1bW8vHQLzy3JprSyhotGJvGH03prPTeRYOKpdXYy2L4W8tZA3lrYvR48NT8+NzIOmreF5m2clrXmE5xxbF3HQqeREKJ/+iTw6W+x+C2PxzLn2zweX5BFXmE5p/Rty22T+9K7nWZ8iTR51eWQuxq2LYdty5xFcQ9s8B4ZBx2HwYm/d/YLjWkPUa0gOsFpYVNAkyCgv+Xil5Zu3MNDH6eTmlfMwMRY/nbhYE7s0drtskSkoVgLxXlOS1rBJijZ5Vz274KSnbBvq7OLAUDb/jD4l9B5FCSe4EwqaNbM3fpFXKYAJ34lY2cxj87LYElmPonxUZqgINJUVJU5y3Pkrna6QLevdQLbAWHRTjdnTHtnUdy+50DSGOg8UoviihyGApz4hR1F5TyxMIt31uYSExHKHWf15ddjumqCgkigqq12gtrmL2DT586yHbVVzmOte0P3iZA43GlRa91bkwlEjpECnLiquKKaf362kZe+2oy1cN1J3blxQg/io8PdLk1EjqRyP+RnQX6Gc9mb7cwArSx2luuoLHbOweLsCzoYRv0Gup3stKhFxrn9DkQCngKcuKKyppbXlm/jmU83sK+smqlDO/Kn0/vQuVW026WJBAdrnYkCFYVQvs9ZZqOiyAlgFUVQ6b1fXug9x3tduhf2bz/4OiHh0KoHNG/tjE2LiHVa0yLjnAkGXcaqC1TEBxTgpFF5PJYPU3bwtwUZ5BSUM65na26b3JeBifofuUiDqS53JgfkLHcmA1QWHwxnB26XF0Jt5dFfJzQSIuMhKt65jk2EdoMgoQe06etcWnbVrE8RF+hbJ41mafYeHpmfwXe5RfTrEMsrVw9ifG+teC5yzKz1hrACp/WsbJ+zgO2uFGfZje3rDs7gbN7WaQ070CoW18m5jop3ltyoG9Ai4w5eImIhVEMZRPyVApz4XNr2Ih6dn8kXWc7M0r9fOIRpwxI1s1Tkp1gLVSWwOwN2fgc7U5zLrjSoKf/x+SHh0HE4jLkJkkY7y26o+1KkSVKAE5/JKSjj7wszmb1uO3FRYdx5Vj8uH9NFM0sleNVWQ36mE8L2ZDnhrKrUe13m3K7c750E4J0IUHengcg4aD8YTrjSaUmLbuUsYBvV0rkd1xnCIl17eyLSeBTgpMHtK63i2SXZvLpsK8bAbyf04IaTexAXFeZ2aSKNqyjXWUZj2zLY8Z2zFdSBcWfNQiG8hffSHMKjIaw5xHeGiBjvxTshoHVvZ0JAXGcwarkWEQU4aUAV1bXMWrqFZ5dkU1JZwwXDO/HH03vTIS7K7dJEfK+qDIq3O+PQNn3uBLeCjc5jkfHQYQiMuh7aD3GW1UjoCc3UGi0iP48CnBw3j8cye10ef1/o7Fk6oU8bbpvcl77ttTCnNAG11U53Z1EulO5xJguU7XGW0yjZ5YS24jxniY0Dwls4y2eMuMZZ+6xtf239JCINSgFOfjZrLQvSdvLEoiyydpUwMDGWxy4YzNie2rNUAoS1UF0GlSXOOLTK/c5lTybs+PbH3Z4HNAtz1j1r3gZadoEuYyC2I8R0dFrWOg6FEA0ZEBHfUYCTY2at5dOM3TyxKIu07cV0b9OcmRcP45xBHTSzVNxjrdMKVrLbuZTvq7PMRoFzu8x7rKzAaUkr3we29vCvF9XSmTBwoNuzVTdnokB0a2d8msaiiYiLFOCk3qy1fLFhD08uymJdTiFJraL5+4VDmDK0I6Eh6h6SRlRRDFu+hI2fOgvWluyG0t0H99o8VEjEwRmb0a2gTZ+D9yNjnS7PiFiI8E4qaNXdmeWpkCYifkoBTn6StZYlmbt5+pNsvs0ppGNcJA+fP4gLTuhEmIKb+JK1TktZcZ4z1mxnihPaclY6LWdhzaFTsrMjQIu20KKdc928DUQnOK1oUS2dGZ4iIk2IApwckbWWRet3MfPTDaTmFdOpZRQPnz+IXwzvRHiogps0oKoyyE+HXeudMWe706BgM+zfcUirmnHGl427FXqcAp1GarcAEQlKCnDyI9ZaPsvM5/GFmaRtL6ZLQjSPXTCYacMS1eIm9VdV5gSw/TugeIezAfr+nc74s4oiZ7zagT059+8ArPO80Cho2xc6j3QmBsQmHpwgcGAcmohIkFOAkx9YunEPf1+YxZqt++jcKorHLxzCVI1xk7o8HijNd5bVKMpxrou3OyGsZDeU7HSuK4t//Nyw5t6uzThnbbRW3Z3dBeKTnKU22g1wNkfX+mgiIkelACcArNm6jycWZfJ19l7ax0by4LSB/DK5s1rcmhprobrcCVflhd6WMG9rWOV+57HqcmdpjZoK51j5vjozOb2bph/YKP2AsGiIaQ8t2kO7gdCzvTMWLaYjxHaAGO9FszdFRBqEAlyQ+y63kCcWZfFZZj6tW4Qz/Zz+XDIqSfuVBoraaqe1a/9OpwWsdLez2Gxpvndm5h5vOCs+uMZZ3b01j8SEONs7hUUfnK2Z0MO7jEaC060Z1+ngJTJewUxEpBEpwAWptO1FPLloA4vTdxEfHcZfz+zLr8d0oXmE/kr4DWshPwNyVjhhrGzvD3cC2L/LCWoHxo7VFRnvzMRs3hriu9TZW9N7iYx1zomMh6h4pxszIsYJbGFRWoRWRMTP6V/rIJOxs5inF29gXupOYiND+dOk3lw5tisxkfoH23XWQsEmZ32zzV84l9L8g49HxP2wBazjcG/XZHvvdTunCzM6QTMzRUSaOAW4IJGxs5iZn2zg45SdtIgI5fen9OSak7oTF6Xg1uishZpKZ7D/9nWwY93B6/J9zjkt2kP3idBtPHQdC7GdFMpEROR7CnBNXPqOYp759IfB7epx3YiPVhg4ZgeCV1VJnTFldfbPrCxyriuKf7xMRuV+53lVJc5z6m7f1CwU2vaDvudAx2HQ9SRo3UtjykRE5IgU4Jogay2fZ+Xz4leb+XLDHgW3I/F4nJBVvP2QJTHyfhi6KosPBrVDZ18eTrNQZ0xZZLz3Os5ZxywixtmmKby5s2VTdAK0HwRtB0BYpI/frIiINCUKcE1IRXUt73+Tx0tfbWbD7hLaxkTw5zP6cOmopOANbtY6K/tnL3YmA5TmH9zYvLzwxxuZh4Q748miWzmBK/rABIAWBycAhMf8+FhE3MHbYVFqPRMREZ9SgGsCCkqreGXZFl5dtpW9pVUM6BjLk78awtmDOgbflleV+51V//O9oS37E6dFDSChpxPO2vX3Libr3dg8NhHiOjvLYTRvA82C7M9MREQCjgJcANu2t4x/fbWJt1bnUFHt4ZS+bbnupO6M7t4K0xRagGqqoLoUqkqdbZmqSpxB/t+vcbYbSvKdyQDF3i2b6q7+HxEL3SfAyX+FnqdBXKJrb0VERKQhKcAFoJTcIp7/YiPzUnYQ2qwZU4d15LqTutOrXYzbpR1krXcQf3GdsWQlULXfu45ZQZ01zfY6wavKG9Yq9zvXPzXeLDQSmrd1Vvxv0xt6THRa2GI7OtsxdRym9cxERKRJUoALENZavtywh+c/38jSjXuJiQzlNyf34KoTu9I2tpEHwFvrtIQdGPB/4Lp4u/fivV1TcfTXiYiD5t6uzMh4pwvzwCD/7y8tnMVlD9yPjIMW7ZyuTm3LJCIiQUoBzs9V1XiYn7aT//18I2nbi2kXG8EdZ/Xl4pFJDbf4bnX5wb0uD7SIlRd47x96zLsbQHXZD1+jWaiz72VcotPy1fdspzUsMt4Z7B/e4uAszANbM2ldMxERkZ9FAc4PWWtJySvivbV5zP12OwWlVXRv05zHfjGYKcM6EhF6mH1KrfVuPO7dcLy80LmuKDzM/cIfblBeU37kYsJjDraSRbeG1n2c7ZliE52wFtvJuW7eVoP/RUREGokCnB/J31/Ju2tzeXdNLht2lxAe2oxJ/dtxwfBOnNy7Dc2aGWdh2MwlznZLxduhZJd3IP8uqK088ouHREBUS+++l/EQnwQdhjr3D7SIRbV0ZmdGJ6iVTERExI8pwLnMWsuqLft4dflW5qfuoLrWckKXljw0bRBnD+pAXGQI7F4PS1+DDYtg23Jn7bLwGGjZxRkLltALWrRxWsGiE5xQFtXy4EblUS2dtclERESkSVCAc0lRWTUffLed/yzfSsbO/cREhvLrUZ25ok81SRVZsH0uvLEOdqY4MzjBWbV/3K3QcxJ0GgEh+vhERESCUcAnAGPMmcDTQAjwL2vtIy6XdFg1tR6+zS3k86w9fLkhn+9yCujCTia32sHT/XbRszqbkJQUWFvqPCEs2glsQy91JgV0nwCxHVx9DyIiIuIfAjrAGWNCgOeASUAusMoYM9dau97Nuqy17CyuICW3iLTcvWzK2U5+bhZdqzcxoNlWHorIpUfUFsI95VAK5ERBh8Ew/HJnXFrHodC6NzQ7zGQFERERCXoBHeCAkUC2tXYTgDHmDWAK4FqAW/XEhcQVZ9LclnAipZxu6qyFFgY2PAbTYTC0PxnaD3Za11r3VneoiIiI1Fugp4ZEIKfO/Vxg1KEnGWOuB64HSEpK8mlBnrBoqmI60SwmgdD41kQktCGseStnd4D2gzDxXbTchoiIiByXQA9w9WKtfQF4ASA5Odn68meNunmWL19eREREhEBvCsoDOte538l7TERERKTJCvQAtwroZYzpZowJBy4C5rpck4iIiIhPBXQXqrW2xhjzO2ABzjIiL1lr01wuS0RERMSnAjrAAVhrPwY+drsOERERkcYS6F2oIiIiIkFHAU5EREQkwCjAiYiIiAQYBTgRERGRAKMAJyIiIhJgFOBEREREAowCnIiIiEiAUYATERERCTAKcCIiIiIBxlhr3a6hURlj8oGtPv4xrYE9Pv4Zcuz0ufgvfTb+SZ+L/9Jn45988bl0sda2OfRg0AW4xmCMWW2tTXa7DvkhfS7+S5+Nf9Ln4r/02finxvxc1IUqIiIiEmAU4EREREQCjAKcb7zgdgFyWPpc/Jc+G/+kz8V/6bPxT432uWgMnIiIiEiAUQuciIiISIBRgGtAxpgzjTGZxphsY8xtbtcTzIwxnY0xS4wx640xacaYW7zHWxljFhljNnivW7pdazAyxoQYY74xxnzovd/NGLPC+9150xgT7naNwcgYE2+MeccYk2GMSTfGjNF3xn3GmD94f4+lGmP+a4yJ1HfGHcaYl4wxu40xqXWOHfY7YhwzvZ/Rd8aY4Q1ZiwJcAzHGhADPAZOB/sDFxpj+7lYV1GqAP1lr+wOjgZu8n8dtwCfW2l7AJ9770vhuAdLr3H8UeNJa2xPYB1zjSlXyNDDfWtsXGILzGek74yJjTCLweyDZWjsQCAEuQt8Zt7wMnHnIsSN9RyYDvbyX64F/NmQhCnANZySQba3dZK2tAt4AprhcU9Cy1u6w1q713t6P8w9RIs5nMst72ixgqisFBjFjTCfgbOBf3vsGOAV4x3uKPhcXGGPigPHAiwDW2iprbSH6zviDUCDKGBMKRAM70HfGFdbaL4CCQw4f6TsyBXjFOpYD8caYDg1ViwJcw0kEcurcz/UeE5cZY7oCw4AVQDtr7Q7vQzuBdm7VFcSeAv4CeLz3E4BCa22N976+O+7oBuQD//Z2b//LGNMcfWdcZa3NAx4HtuEEtyJgDfrO+JMjfUd8mgsU4KRJM8a0AN4FbrXWFtd9zDpTsDUNuxEZY84Bdltr17hdi/xIKDAc+Ke1dhhQyiHdpfrOND7veKopOAG7I9CcH3fhiZ9ozO+IAlzDyQM617nfyXtMXGKMCcMJb69Za9/zHt51oAnbe73brfqC1FjgPGPMFpxhBqfgjLuK93YPgb47bskFcq21K7z338EJdPrOuOs0YLO1Nt9aWw28h/M90nfGfxzpO+LTXKAA13BWAb28M4PCcQaZznW5pqDlHVf1IpBurX2izkNzgSu8t68A5jR2bcHMWnu7tbaTtbYrznfkU2vtpcAS4ALvafpcXGCt3QnkGGP6eA+dCqxH3xm3bQNGG2Oivb/XDnwu+s74jyN9R+YCv/bORh0NFNXpaj1uWsi3ARljzsIZ3xMCvGStfdDdioKXMWYc8CWQwsGxVnfgjIN7C0gCtgK/tNYeOiBVGoExZgLwP9bac4wx3XFa5FoB3wCXWWsrXSwvKBljhuJMLgkHNgFX4fxHX98ZFxlj7gV+hTO7/hvgWpyxVPrONDJjzH+BCUBrYBcwA5jNYb4j3sD9LE6XdxlwlbV2dYPVogAnIiIiEljUhSoiIiISYBTgRERERAKMApyIiIhIgFGAExEREQkwCnAiIiIiAUYBTkSkDmNMV2NM6jGcf6UxpmM9znn2+KsTEXEowImIHJ8rcbY4EhFpNApwIiI/FmqMec0Yk26Mece7Cv50Y8wqY0yqMeYF7+rqFwDJwGvGmHXGmChjzAhjzFJjzLfGmJXGmBjva3Y0xsw3xmwwxjzm4nsTkSZAAU5E5Mf6AP+w1vYDioEbgWettSOstQOBKOAca+07wGrgUmvtUKAWeBO4xVo7BGcfy3Lvaw7FWU1/EPArY0zdPRJFRI6JApyIyI/lWGu/9t7+DzAOmGiMWWGMSQFOAQYc5nl9gB3W2lUA1tpia22N97FPrLVF1toKnL0su/j2LYhIUxbqdgEiIn7o0D0GLfAPINlam2OMuQeIPMbXrLtPZS36/Ssix0EtcCIiP5ZkjBnjvX0J8JX39h5jTAvggjrn7gcOjHPLBDoYY0YAGGNijDEKaiLS4PSLRUTkxzKBm4wxL+F0d/4TaAmkAjuBVXXOfRl43hhTDozBGef2jDEmCmf822mNWLeIBAlj7aE9BSIiIiLiz9SFKiIiIhJgFOBEREREAowCnIiIiEiAUYATERERCTAKcCIiIiIBRgFOREREJMAowImIiIgEGAU4ERERkQDz/yvj4g87ezzbAAAAAElFTkSuQmCC\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAnAAAAFzCAYAAAC+bzSQAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8vihELAAAACXBIWXMAAAsTAAALEwEAmpwYAABMHklEQVR4nO3dd3yV5f3/8deVkEl22CMkbALIMAzBvUBFEauts4q21ta2avuzdeG2jq911VVbB1atW0BRQCg4UBBwQEgYYSZhJJC91/X7474jARlBOblzct7Px+M8zjn3uc/J5+Rw4M01jbUWEREREfEfQV4XICIiIiKHRwFORERExM8owImIiIj4GQU4ERERET+jACciIiLiZxTgRERERPxMO68LaGkdOnSwycnJXpchIiIickgrVqzYZa3tuO/xgAtwycnJLF++3OsyRERERA7JGLNlf8fVhSoiIiLiZxTgRERERPyMApyIiIiInwm4MXD7U1tbS05ODlVVVV6XEpDCw8Pp0aMHISEhXpciIiLiFxTggJycHKKjo0lOTsYY43U5AcVay+7du8nJySElJcXrckRERPyCulCBqqoqEhMTFd48YIwhMTFRrZ8iIiKHQQHOpfDmHf3uRUREDo8CXCuwefNmhgwZ8oPjjz32GBUVFR5UJCIiIq2ZAlwrpgAnIiIi+6MA10rU1dVxySWXMGjQIM4//3yeeOIJtm3bxkknncRJJ51EfX09V1xxBUOGDGHo0KE8+uijXpcsIiIiHtEs1H3c9f5qMraVHNHXTO0Wwx1nDz7oOWvXruX5559n/PjxXHnlldTU1NCtWzcWLlxIhw4dWLFiBbm5uaSnpwNQVFR0RGsUERER/6EWuFaiZ8+ejB8/HoBLL72Uzz//fK/He/fuzcaNG/nDH/7AnDlziImJ8aJMERGRgFdcUcv/1uz0tAa1wO3jUC1lvrLvTMx978fHx/Pdd98xd+5cnn32Wd58801eeOGFlixRREQkoDU0WN5ekcMDc9ZQWVPPkptPITbSm0Xo1QLXSmzdupUvv/wSgNdee41jjz2W6OhoSktLAdi1axcNDQ387Gc/49577+Xrr7/2slwREZGAkp5bzM+e/YK/vLOS3h3a885vx3kW3kAtcK3GgAEDeOqpp7jyyitJTU3lt7/9LaGhoUycOJFu3brx2GOPMXXqVBoaGgC4//77Pa5YRESk7SuurOXv89byypItJLQP5eELhnHeiO4EBXm7hqmx1npaQEtLS0uzy5cv3+tYZmYmgwYN8qgiAX0GIiLSulhr+WDldu56P4OC8mp+eUwyN5zWn9iIlm11M8assNam7XtcLXAiIiIiTWQXVDBtZjqL1uYztHssL00dxZDusV6XtRcFOBERERGgrr6BFxdv5pGP12EM3D4plcvHJRPscXfp/ijAiYiISMBLzy3mpndXkp5bwikDO3H3uUPoHhfhdVkHpAAnIiIiAauqtp7H5q/nX59tJD4ylKcuHsmZQ7v8YDmv1kYBTkRERALSko27ufndVWzaVc7P03pw65mpni4NcjgU4ERERCSgFJbX8NDcNfz3q2ySEiJ59VdjGN+3g9dlHRYFOBEREQkI9Q2WN5Zl89DcNZRW1XH18b254dT+RIQGe13aYdNODEJycjK7du067OdNnz6dfv360a9fP6ZPn77fc2688UYGDhzIUUcdxZQpUygqKvqJ1YqIiBy+b7OLmPL0Ym55bxX9O0fz4R+P45YzB/lleAMFOL9XV1fnyc8tKCjgrrvuYunSpXz11VfcddddFBYW/uC80047jfT0dFauXEn//v21g4SIiLSo4opabn53JVOeXsyO4ioev3A4b1w9lgFdor0u7SdRF+q+ProJdqw6sq/ZZSic8cBBT3nllVd44oknqKmpYcyYMTz99NO89NJLPPjgg8TFxTFs2DDCwsJ48sknueKKKwgPD+ebb75h/PjxXHvttVx77bXk5+cTGRnJv/71LwYOHEh+fj7XXHMNW7duBeCxxx5j/Pjx7N69m4suuojc3FyOOeYYGnfjuP3220lISOD6668H4NZbb6VTp05cd911P6h37ty5nHbaaSQkJABOUJszZw4XXXTRXuedfvrp398eO3Ysb7/99o/+NYqIiByOOenbmTZzNQXlNVw1PoXrTu1HdLh/TFI4FLXAtQKZmZm88cYbLF68mG+//Zbg4GBeffVV7rnnHpYsWcLixYtZs2bNXs/Jycnhiy++4JFHHuHqq6/mH//4BytWrODhhx/md7/7HQDXXXcdN9xwA8uWLeOdd97hV7/6FQB33XUXxx57LKtXr2bKlCnfB7wrr7ySl19+GYCGhgZef/11Lr300v3WnJubS8+ePb+/36NHD3Jzcw/6Pl944QXOOOOMH/dLEhERaaa8kiqu+c8KrnnlazpGhTHz2vHcNim1zYQ3UAvcDx2ipcwXFixYwIoVKxg1ahQAlZWVfPHFF5xwwgnft3BdcMEFrFu37vvnXHDBBQQHB1NWVsYXX3zBBRdc8P1j1dXVAMyfP5+MjIzvj5eUlFBWVsann37Ku+++C8BZZ51FfHw84IyFS0xM5JtvvmHnzp2MGDGCxMTEI/Ie77vvPtq1a8cll1xyRF5PRERkX9Za3lqew72zM6iqa+AvEwfw6+N6ExLc9tqrFOBaAWstl19++V7jw2bMmMF77713wOe0b98ecFrK4uLi+Pbbb39wTkNDA0uWLCE8PLzZtfzqV7/ipZdeYseOHVx55ZUHPK979+4sWrTo+/s5OTmceOKJ+z33pZde4oMPPmDBggWtfmFEERHxTxnbSrh9ZjrLtxQyOjmB+382lD4do7wuy2faXiT1Q6eccgpvv/02eXl5gDNBYMSIEXzyyScUFhZSV1fHO++8s9/nxsTEkJKSwltvvQU4YfC7774DnPFn//jHP74/tzHkHX/88bz22msAfPTRR3tNPpgyZQpz5sxh2bJlTJgw4YA1T5gwgXnz5lFYWEhhYSHz5s3b7/lz5szhoYceYtasWURGRh7Gb0VEROTQiitruWNmOpP+8Rkbd5Xz4M+G8vrVY9t0eAO1wLUKqamp3HvvvZx++uk0NDQQEhLCU089xS233MLo0aNJSEhg4MCBxMbG7vf5r776Kr/97W+59957qa2t5cILL2TYsGE88cQTXHvttRx11FHU1dVx/PHH8+yzz3LHHXdw0UUXMXjwYMaNG0dSUtL3rxUaGspJJ51EXFwcwcEHnlqdkJDAtGnTvu/2bZwAAU4r3jXXXENaWhq///3vqa6u5rTTTgOciQzPPvvskfrViYhIgGposLz9dQ4PfrSGwooaLh3biz+fNsBvdlL4qUzjDMRAkZaWZpcvX77XsczMTAYNGuRRRQdWVlZGVFQUdXV1TJkyhSuvvJIpU6b49Gc2NDQwcuRI3nrrLfr16+fTn9VUa/0MRESk9cnYVsK0mems2FLI0b3iueucwQzpvv9GDn9njFlhrU3b97ha4FqxO++8k/nz51NVVcXpp5/Oueee69Ofl5GRwaRJk5gyZUqLhjcREZHmKK2q5dGP1zP9y83ERoTw0PlHcf7IHgQFBd74agW4Vuzhhx9u0Z+XmprKxo0b9zq2atUqLrvssr2OhYWFsXTp0pYsTUREApi1ltmrtnPPBxnklVZz8egkbpwwgLjIUK9L84wCnBzU0KFD9zvDVUREpCVkF1Rw64x0Pl2Xz5DuMfzzsjSG94zzuizPKcC5rLVa4sIjgTYOU0REDq2uvoEXFm/ikY/XEWwMd56dymXHJBMcgN2l+6MAB4SHh7N7924SExMV4lqYtZbdu3cf1lp1IiLStq3MKeKmd1aRsb2EUwd15u7Jg+kWF+F1Wa2KAhzONlA5OTnk5+d7XUpACg8Pp0ePHl6XISIiHquoqePv89bx4uJNdIgK49lLRzJhcBc1ruyHAhwQEhJCSkqK12WIiIgErE/X5XPLe6vIKazkkjFJ/PWMgcS0ob1LjzQFOBEREfFMYXkN98zO4N2vc+ndsT1v/uYYRqckeF1Wq6cAJyIiIi3OWsus77Zx9/sZFFfW8vuT+vL7k/sSHnLgXYBkDwU4ERERaVG5RZXc9t4qFq7NZ1iPWF751RgGdY3xuiy/ogAnIiIiLaK+wfKfLzfz0Ny1WAvTJqVyxTgtDfJjKMCJiIiIz63dUcpN767km61FnNC/I/eeO4SeCZFel+W3FOBERETEZypq6nhiQRb//mwjMREhPH7hcM4Z1k1Lg/xEQb58cWPMDcaY1caYdGPMf40x4caYFGPMUmNMljHmDWNMqHtumHs/y308ucnr3OweX2uMmdDk+ET3WJYx5iZfvhcRERE5PAsyd3LaI5/y7CcbOG9kd+b/6QQmD++u8HYE+CzAGWO6A38E0qy1Q4Bg4ELgQeBRa21foBC4yn3KVUChe/xR9zyMManu8wYDE4GnjTHBxphg4CngDCAVuMg9V0RERDy0vbiS3/xnOVdNX05kaDBv/uYYHjp/GAntA3fz+SPN112o7YAIY0wtEAlsB04GLnYfnw7cCTwDTHZvA7wNPGmciD4ZeN1aWw1sMsZkAaPd87KstRsBjDGvu+dm+Pg9iYiIyH7U1Dn7lz6xYD0N1vKXiQP41bG9CW3n0w6/gOSzAGetzTXGPAxsBSqBecAKoMhaW+eelgN0d293B7Ld59YZY4qBRPf4kiYv3fQ52fscH+ODtyIiIiKH8Pn6XdwxK50N+eWcOqgzd5ydqkkKPuSzAGeMicdpEUsBioC3cLpAW5wx5mrgaoCkpCQvShAREWmTthVVct/sTGav2k6vxEhevGIUJw3s5HVZbZ4vu1BPBTZZa/MBjDHvAuOBOGNMO7cVrgeQ656fC/QEcowx7YBYYHeT442aPudAx/dirX0OeA4gLS3N/vS3JiIiEthq6xt4cfEmHpvvdJf++bT+/Pr43tpJoYX4MsBtBcYaYyJxulBPAZYDC4HzgdeBy4GZ7vmz3Ptfuo//z1prjTGzgNeMMY8A3YB+wFeAAfoZY1JwgtuF7BlbJyIiIj6yYksBt76XzpodpZw6qBN3nD1Y3aUtzJdj4JYaY94GvgbqgG9wWsFmA68bY+51jz3vPuV54D/uJIUCnECGtXa1MeZNnMkJdcC11tp6AGPM74G5ODNcX7DWrvbV+xEREQl0heU1PDhnDa8vy6ZbbDjPXXY0pw/u4nVZAclYG1g9imlpaXb58uVelyEiIuI3rLXM/HYbd3/gbDx/1bEpXHdKP9qHaT8AXzPGrLDWpu17XL95EREROaCcwgpufS+dT9blM6xnHK9MGUpqN2087zUFOBEREfmB+gbL9C828/C8tQDccXYqvzxGG8+3FgpwIiIispc1O0r46zur+C67iBMHOBvP94jXJIXWRAFOREREAKiqrefJ/2Xx7CcbtPF8K6cAJyIiIizZuJtb3l3Fxl3lnDeyO7edlaq9S1sxBTgREZEAVlxZywMfreG/X22lZ0IE/7lqNMf16+h1WXIICnAiIiIByFrLrO+2cc8HmRSUV3P18b25/tR+RIYqGvgDfUoiIiIBZvOucqbNTOez9bs4qkcsL00dxZDusV6XJYdBAU5ERCRAVNfV89wnG/nHwixCg4O4e/JgLhnTS0uD+CEFOBERkQDwxYZd3DYjnY355Zw1tCu3n51K55hwr8uSH0kBTkREpA3LL63mvtkZzPh2G0kJkbw4dRQnDejkdVnyEynAiYiItEH1DZbXlm7hoblrqaqt5w8n9+Xak/oSHhLsdWlyBCjAiYiItDEZ20q4+T1nJ4VxfRK559wh9OkY5XVZcgQpwImIiLQRFTV1PD5/Pf/+fBPxkSE89ovhTB6unRTaIgU4ERGRNmDh2jymzUgnp7CSC0f15KYzBhIXqZ0U2ioFOBERET+2o7iKe2ZnMHvldvp0bM8bV49lTO9Er8sSH1OAExER8UO19Q1M/2Izj368jtoGyw2n9ueaE3sT1k6TFAKBApyIiIifWba5gGkz0lmzo5STBnTkznMG0yuxvddlSQtSgBMREfETRRU13Dc7k7dW5NA9LoJ/XnY0p6d21iSFAKQAJyIi4gc+WrWdaTNXU1RRwzUn9OGPp/TVxvMBTJ+8iIhIK5ZXUsXtM1czZ/UOhnSPYfqVoxjcTRvPBzoFOBERkVbIWstbK3K494MMquoa+OvEgfz6uBTaBQd5XZq0AgpwIiIirczG/DJufS+dLzfuZlRyPA/87CjtpCB7UYATERFpJarr6nl20UaeWphFWEgQ900ZwkWjkggK0iQF2ZsCnIiISCvw1aYCbn53JRvyy5l0VFduPzuVTtHhXpclrZQCnIiIiId2lVVz/4dreOdrZ2mQF6eO4qQBnbwuS1o5BTgREREP1DdYXlu6hf+bu5bK2np+e2If/nCylgaR5tGfEhERkRb2zdZCps1MJz23hPF9E7nrnCH07aRJCtJ8CnAiIiItpLiilgfnruG/X22lU3QYT148grOGdtVOCnLYFOBERER8zFrLjG9zuW92JoUVtVw5PoUbTutPVJj+GZYfR39yREREfGhDfhm3uWu6De8Zx/Qrh2gnBfnJFOBERER8oKq2nqcXbeDZRRsI15pucoQpwImIiBxhi7N2cduMdDbtKufc4d249axUOkaHeV2WtCEKcCIiIkfIrrJq7pudyXvf5JKcGMkrV43h2H4dvC5L2iAFOBERkZ/IWsuby7P524drqKip448n9+V3J/UlPCTY69KkjVKAExER+Qmy8sq45b1VfLWpgNEpCfxtyhD6dor2uixp4xTgREREfoTqunqeXriBZxZtICI0mId+dhQXpPXQmm7SIhTgREREDtPSjbu55b1VbMgv55xh3Zg2SZMUpGUpwImIiDRTcWUtD3yUyX+/yqZHfAQvTR3Fidp4XjygACciInII1lo+St/BHbNWs7usmquP7831p/bTxvPiGf3JExEROYjtxZVMm7Ga+Zk7GdwthhcuH8XQHtpJQbylACciIrIfNXUNvLh4E48vWE+Dtdx8xkCuOjaFdsFBXpcmogAnIiKyry+ydnH7rNVk5ZVx6qBO3D5pMEmJkV6XJfI9BTgRERHXjuIq7vswk/e/20bPhAievzyNUwZ19roskR9QgBMRkYDX0GD577Kt3P/hGmrqG7j+1H5cc0If7aQgrZYCnIiIBLQtu8v56zsrWbKxgHF9Ern/vKH0SmzvdVkiB6UAJyIiAam+wfLi4k08PG8tIUFBPHDeUH4xqqd2UhC/oAAnIiIBJ3N7CTe/u4pvs4s4ZWAn7p0yhK6xEV6XJdJsCnAiIhIwKmvqeXzBev792UZiIkJ47BfDmTy8m1rdxO8owImISEBYtDaP22akk1NYyc/TenDzGYOIbx/qdVkiP4oCnIiItGl5JVXc/UEGH6zcTp+O7Xn96rGM7Z3odVkiP4kCnIiItEn1DZZXl27h/+aspbq+gRtO7c81J/YmrJ2WBhH/pwAnIiJtzqqcYm6dsYqVOcUc168Dd08eQkoHLQ0ibYcCnIiItBll1XU8PHctL3+5mcSoMJ64aARnH9VVkxSkzVGAExGRNuGTdfnc8u4qthVXctnYXvz59AHERoR4XZaITyjAiYiIXyuuqOWe2Rm8vSKHvp2iePuacRzdK97rskR8KsiXL26MiTPGvG2MWWOMyTTGHGOMSTDGfGyMWe9ex7vnGmPME8aYLGPMSmPMyCavc7l7/npjzOVNjh9tjFnlPucJozZyEZGAMnf1Dk599BPe+yaXa0/qwwd/OFbhTQKCTwMc8Dgwx1o7EBgGZAI3AQustf2ABe59gDOAfu7lauAZAGNMAnAHMAYYDdzRGPrcc37d5HkTffx+RESkFdhWVMk1/1nBb/6zgg5RYcy8djw3ThiozeclYPisC9UYEwscD1wBYK2tAWqMMZOBE93TpgOLgL8Ck4GXrbUWWOK23nV1z/3YWlvgvu7HwERjzCIgxlq7xD3+MnAu8JGv3pOIiHirtr6BFxdv4rH562mwlhsnDODq43sTEuzr9giR1uWwApwxJgiIstaWNOP0FCAfeNEYMwxYAVwHdLbWbnfP2QF0dm93B7KbPD/HPXaw4zn7OS4iIm3Q8s0F3DYjnTU7SjllYCfuPGcwPRMivS5LxBOH/C+LMeY1Y0yMMaY9kA5kGGNubMZrtwNGAs9Ya0cA5ezpLgXAbW2zh1/24THGXG2MWW6MWZ6fn+/rHyciIkfQ7rJq/vL2d5z/7JeUVNbyz8uO5t+Xpym8SUBrTptzqtvidi5O92QKcFkznpcD5Fhrl7r338YJdDvdrlHc6zz38VygZ5Pn93CPHex4j/0c/wFr7XPW2jRrbVrHjh2bUbqIiHitvsHyypItnPz3T3j361x+c3xvPv7TCUwY3EXruknAa06ACzHGhOAEuFnW2lqa0Wpmrd0BZBtjBriHTgEygFlA40zSy4GZ7u1ZwC/d2ahjgWK3q3UucLoxJt6dvHA6MNd9rMQYM9adffrLJq8lIiJ+7LvsIqY8vZjbZqQzqGs0H113HDefOYj2YVr9SgSaNwbun8Bm4DvgU2NML6A5Y+AA/gC8aowJBTYCU3FC45vGmKuALcDP3XM/BM4EsoAK91ystQXGmHuAZe55dzdOaAB+B7wEROC0DmoCg4iIHyuurOX/5q7h1aVb6RAVxuMXDuecYd3U4iayD+MMQzvMJxnTzlpb54N6fC4tLc0uX77c6zJERKQJay0fpe/gzlmr2VVWzeXjkvnTaf2JDtdOChLYjDErrLVp+x4/YAucMeZPh3jNR35yVSIiEvByiyq5fUY6C9bkMbhbDP++PI2jesR5XZZIq3awLtRo93oAMApnjBrA2cBXvixKRETavvoGy/QvNvPwvLVYC7eeOYip45NppzXdRA7pgAHOWnsXgDHmU2CktbbUvX8nMLtFqhMRkTYpc3sJN72zku9yijlxQEfumTxEy4KIHIbmTGLoDNQ0uV/DnsV3RUREmq2qtp4nFqznuU83EhsRokkKIj9ScwLcy8BXxpj33Pvn4sz8FBERabYvN+zm5ndXsnl3Becf3YNbzxxEfPtQr8sS8UsHDXDu+mov4yzPcZx7eKq19htfFyYiIm1DUUUNf/swkzeX55CUEMkrV43h2H4dvC5LxK8dNMBZa60x5kNr7VDg6xaqSURE2gBrLbO+28bd72dQVFnLNSf04bpT+hERGux1aSJ+rzldqF8bY0ZZa5cd+lQRERHILqjg1hnpfLoun2E94/jPlKGkdovxuiyRNqM5AW4McIkxZgvOhvQGp3HuKJ9WJiIifqeqtp5/fbqRpxZlEWwMd50zmEvH9iI4SJMURI6k5gS4CT6vQkRE/N7CtXncNWs1m3dXcObQLtx2Vird4iK8LkukTTpkgLPWbgEwxnQCwn1ekYiI+JXsggru+SCDeRk76d2xPf+5ajTH9evodVkibdohA5wx5hzg70A3IA/oBWQCg31bmoiItGZ19Q28sHgTj3y8DoPhrxMHctWxKYS2004KIr7WnC7Ue4CxwHxr7QhjzEnApb4tS0REWrPM7SX89Z2VrMwp5tRBnbl78mB1l4q0oOYEuFpr7W5jTJAxJshau9AY85ivCxMRkdanuq6eJ/+XxTOLNhAbEcKTF4/grKFdtZOCSAtrToArMsZEAZ8Crxpj8nBmo4qISABZsaWQv76zkqy8Ms4b0Z1pk1K1k4KIR5oT4CYDlcANwCVALHC3L4sSEZHWo6KmjofnruPFLzbRNSacF6eO4qQBnbwuSySgNSfAXQh8aq1dD0z3cT0iItKKfLFhFze9s4qtBRVcOjaJv04cSHR4iNdliQS85gS4JOCfxpgUYDlOV+pn1tpvfVmYiIh4p6Sqlgc/WsOrS7fSKzGS168ey9jeiV6XJSKu5qwDdweAMSYC+DVwI/AYoM3sRETamMb9S++dncnusmp+fVwKfzptgPYvFWllmrMO3G3AeCAK+Ab4f8BnPq5LRERa2Ib8Mm6fmc7irN0M7R7L85encVSPOK/LEpH9aE4X6nlAHTAb+AT40lpb7dOqRESkxVTV1vPUwiz++clGwkKCuGfyYC4eo/1LRVqz5nShjjTGxOC0wp0GPGeMybPWHuvz6kRExGestXycsZO7P8ggp7CSc4d345azBtEpWrsmirR2zelCHQIcB5wApAHZqAtVRMSvbd5Vzp3vr2bR2nz6dYritV+PYVyfDl6XJSLN1Jwu1AdwAtsTwDJrba1vSxIREV+prHG6S5/7dCOh7YK47axBXD4umZBg7V8q4k+a04U6yZ2BmqTwJiLivz5dl88t760ip7CSKSO6c/MZA+kUo+5SEX/UnC7Us4GHgVAgxRgzHLjbWnuOj2sTEZEjYHdZNffOzuS9b3Lp3bG91nQTaQOa04V6JzAaWARgrf3WXdRXRERaMWst736dy72zMyirruOPJ/fldyf1JTxEa7qJ+LvmBLhaa22xMXtNJ7c+qkdERI6ArLxS7pi1msVZuxmZFMcDPzuK/p2jvS5LRI6Q5gS41caYi4FgY0w/4I/AF74tS0REfoyy6jqeWLCeFz7fRGRoMPdMHswlY3oRpDXdRNqU5gS4PwC3AtXAa8Bc4F5fFiUiIoencQusv32Yyc6San6e1oO/TBxIh6gwr0sTER84aIAzxgQDs621J+GEOBERaWU25Jdx23vpfLlxN0O6x/DMpUczMine67JExIcOGuCstfXGmAZjTKy1trilihIRkUOrrqvnmUUbeHrhBsJDgrj33CFcNDpJW2CJBIDmdKGWAauMMR8D5Y0HrbV/9FlVIiJyUF9u2M2tM1axMb+cc4Z1Y9qkVDpGq7tUJFA0J8C9615ERMRjheU1/O3DTN5akUPPhAimXzmaE/p39LosEWlhzdmJYXpLFCIiIgfWOEnh7vczKKqs5ZoT+nDdKf2ICNWabiKBqDktcCIi4qGtuyu4dcYqPlu/i2E943jlvKEM6hrjdVki4iEFOBGRVqq2voEXPt/Eo/PXEWwMd50zmEvH9tIkBRFpfoAzxkRaayt8WYyIiDhWbCng1vfSWbOjlFMHdebuyYPpFhfhdVki0ko0ZzP7ccC/gSggyRgzDPiNtfZ3vi5ORCTQFJbX8OCcNby+LJuuseH887KjOT21M/tsZygiAa45LXCPAhOAWQDW2u+MMcf7tCoRkQBjreWdr3P524eZFFfWcvXxvbnulH60D9NIFxH5oWb9zWCtzd7nf3/1vilHRCTwbMgv49b3VrFkYwEjk+K4b4omKYjIwTUnwGW73ajWGBMCXAdk+rYsEZG2r7qunmcXbeSphVmEhwTxtylDuXBUT208LyKH1JwAdw3wONAdyAXmAdf6sigRkbZu6cbd3PLeKjbkl3P2sG5MmzSITtHhXpclIn6iOQHOWGsv8XklIiIBoLC8hvs/yuTN5c5OCi9NHcWJAzp5XZaI+JnmBLjFxpjNwBvAO9baIp9WJCLSBjWdpFBSWctvTujN9af0104KIvKjNGcrrf7GmNHAhcCtxpgM4HVr7Ss+r05EpA3Iyivjthl7Jin87byhDOyiSQoi8uM1dxbqV8BXxpi/AY8A0wEFOBGRg6iqrefpRRt4dtEGTVIQkSOqOQv5xgBTcFrg+gDvAaN9XJeIiF/7ImsXt85IZ9OuciYP78ZtZ6XSMTrM67JEpI1oTgvcd8AM4G5r7Ze+LUdExL/tLqvmvtmZvPtNLr0SI/nPVaM5rl9Hr8sSkTamOQGut7XW+rwSERE/1tBgeXN5Ng/MWUN5dR1/OLkv157Ul/AQTVIQkSPvgAHOGPOYtfZ6YJYx5gcBzlp7ji8LExHxF+m5xUybmc43W4sYnZzAfVOG0K9ztNdliUgbdrAWuP+41w+3RCEiIv6muLKWR+at5T9LtpDQPpRHfj6MKSO6a+N5EfG5AwY4a+0K9+Zwa+3jTR8zxlwHfOLLwkREWitrLe9946zpVlBew2Vje/Gn0wcQGxHidWkiEiCaMwbucpyttJq6Yj/HRETavNXbirlj5mqWbylkeM84Xpo6miHdY70uS0QCzMHGwF0EXAykGGNmNXkoGijwdWEiIq1JUUUNf5+3jleXbiE+MpSHzj+K80f20JpuIuKJg7XAfQFsBzoAf29yvBRY6cuiRERaC2ud2aUPzllLUUUNvzwmmRtO66/uUhHx1MHGwG0BtgDHtFw5IiKtx6Zd5dz87kqWbCxgdHICd00ezKCu2gJLRLwXdKgTjDFjjTHLjDFlxpgaY0y9MaakuT/AGBNsjPnGGPOBez/FGLPUGJNljHnDGBPqHg9z72e5jyc3eY2b3eNrjTETmhyf6B7LMsbcdFjvXETkAGrrG3hm0QYmPvYpq7eV8MB5Q3njN2MV3kSk1ThkgAOeBC4C1gMRwK+Apw7jZ1wHZDa5/yDwqLW2L1AIXOUevwoodI8/6p6HMSYVZxuvwcBE4Gk3FAa7dZwBpAIXueeKiPxo6bnFnPvUYh6cs4aTBnRiwZ9O4MLRSVoaRERaleYEOKy1WUCwtbbeWvsiTpA6JGNMD+As4N/ufQOcDLztnjIdONe9Pdm9j/v4Ke75k4HXrbXV1tpNQBbOXqyjgSxr7UZrbQ3wunuuiMhhK66o5faZ6Zzz5Ofkl1bz7KUjefayo+kUE+51aSIiP9CcZUQq3G7Ob40xD+FMbGhW8AMeA/6CM3MVIBEostbWufdzgO7u7e5ANoC1ts4YU+ye3x1Y0uQ1mz4ne5/jY/ZXhDHmauBqgKSkpGaWLiKBoHELrIfmapKCiPiP5gS4y4Bg4PfADUBP4GeHepIxZhKQZ61dYYw58SfU+JNZa58DngNIS0vTvq4iAsB32UXcPjOd73KKGZ2cwJ3nDCa1m8a5iUjrd8gA585GBagE7jqM1x4PnGOMORMIB2JwFv+NM8a0c1vhegC57vm5OOEwxxjTDogFdjc53qjpcw50XETkgIoranlo7hpe+2orHaLCeOwXw5k8vJvGuYmI3zjYQr6rgAO2VllrjzrYC1trbwZudl/rROD/WWsvMca8BZyPM2btcmCm+5RZ7v0v3cf/Z6217iLCrxljHgG6Af2ArwAD9DPGpOAEtwtxFh4WEdkvay0zvs3lvtnOFlhTx6Vww2n9iA5Xd6mI+JeDtcBN8tHP/CvwujHmXuAb4Hn3+PPAf4wxWTg7PVwIYK1dbYx5E8gA6oBrrbX1AMaY3wNzcbp4X7DWrvZRzSLi57Lyypg2I50vN+5meM84pl85msHdtAWWiPgnY21gDQlLS0uzy5cv97oMEWkhVbX1PLUwi2c/2UBESDA3nTGIC0f11BZYIuIXjDErrLVp+x4/5Bg4Y0wpe7pSQ4EQoNxaq5G+ItKqfbIun2kz0tlaUMF5I7pzy1mD6BAV5nVZIiI/WXMmMTQuAUKTddnG+rIoEZGfIq+kirs/yOCDldvp3bE9r/16DOP6dPC6LBGRI6Y5y4h8zzr9rTOMMXcA2rpKRFqV+gbLq0u38H9z1lJd38CfTuvPb07oTVi7YK9LExE5oprThXpek7tBQBpQ5bOKRER+hNXbirnlvXS+yy7i2L4duOfcIaR0aO91WSIiPtGcFrizm9yuAzajLatEpJWoqKnjsfnref7zTcRFhPD4hcM5Z5jWdBORtq05Y+CmtkQhIiKH639rdjJtxmpyiyq5aHRP/jpxIHGRoV6XJSLic83pQk0B/gAkNz3fWnuO78oSETmwnSVV3PX+aj5ctYN+naJ465pjGJWc4HVZIiItpjldqDNwFtl9H2jwaTUiIgfROEnhoTlrqa1v4MYJA/j1cb0JbRfkdWkiIi2qOQGuylr7hM8rERE5iKaTFI7r14F7Jg8hWZMURCRANSfAPe4uGzIPqG48aK392mdViYi4yqrrePTjdby4eBMJ7UM1SUFEhOYFuKHAZcDJ7OlCte59ERGfsNYyJ30Hd72fwc7SKi4encRfJgwkNlIbz4uINCfAXQD0ttbW+LoYERGA7IIKbp+ZzsK1+QzqGsPTl45kZFK812WJiLQazQlw6UAckOfbUkQk0FXX1fPPTzby1MIsgoMMt501iCvGJdMuWJMURESaak6AiwPWGGOWsfcYOC0jIiJHzKfr8rlj1mo27SrnzKFdmDYpla6xEV6XJSLSKjUnwN3h8ypEJGBtL67k3g8ymb1qO8mJkUy/cjQn9O/odVkiIq1ac3Zi+KQlChGRwFJVW8/zn2/iqYVZ1DdY/nRaf64+vjfhIdp4XkTkUJqzE0MpzqxTgFAgBCi31sb4sjARaZustcxdvZP7Pswgu6CSCYM7c+uZqSQlRnpdmoiI32hOC1x0423jLLw0GRjry6JEpG1au6OUu95fzRcbdjOgczSv/moM4/t28LosERG/05wxcN+z1lpghruw702+KUlE2prSqloe/Xg907/cTFRYO+6ePJiLRydpdqmIyI/UnC7U85rcDQLSgCqfVSQibYa1llnfbeO+2Znkl1Vz0egkbjx9APHtQ70uTUTErzWnBe7sJrfrgM043agiIge0fmcpt89czZcbd3NUj1j+9cs0hvWM87osEZE2oTlj4Ka2RCEi0jaUVdfxxIL1vPD5JtqHtePec4dw0egkgoO0d6mIyJHSnC7U6cB11toi93488Hdr7ZU+rk1E/Ehjd+nfPsxkZ0k1v0jryV8mDiAxKszr0kRE2pzmdKEe1RjeAKy1hcaYEb4rSUT8zdodpdw+M52lmwoY2j2WZy89mhHau1RExGeaE+CCjDHx1tpCAGNMQjOfJyJtXFl1HY/PX8cLizcTHd6O+6YM4cJR6i4VEfG15gSxvwNfGmPecu9fANznu5JEpLWz1vJR+g7ufj+DHSVVXDiqJ3+dOFCzS0VEWkhzJjG8bIxZDpzsHjrPWpvh27JEpLXavKuc22et5tN1+aR2jeHpS0cyUt2lIiItqlldoW5gU2gTCWBVtfU8vWgDz36ygbDgIO44O5XLxvbSYrwiIh7QWDYROaT5GTu58/3V5BRWcs6wbtx21iA6xYR7XZaISMBSgBORA9qyu5y73s/gf2vy6Ncpiv/+eizH9En0uiwRkYCnACciP1BVW88zizbwzCcbCAky3HrmIK4Yn0yIuktFRFoFBTgR+Z61lvmZedz9wWqyCyqZdFRXbjsrlS6x6i4VEWlNFOBEBHBml975/moWrc2nX6coXvv1GMb16eB1WSIish8KcCIBrrKmnqcXZfHPTzYS2i6I284axOXj1F0qItKaKcCJBLCms0vPHd6NW87U7FIREX+gACcSgLILKrhz1moWuLNLX796LGN7a3apiIi/UIATCSA1dQ3885MNPLkwi+Agwy1nDmTq+BR1l4qI+BkFOJEA8dWmAm55bxVZeWWcObQL0yal0jU2wuuyRETkR1CAE2njiipquP/DNbyxPJvucRG8eMUoThrYyeuyRETkJ1CAE2mjrLW8900u983OpKiylt+c0JvrTulHZKi+9iIi/k5/k4u0QWt3lDJtZjpfbSpgeM84XjlvKIO6xnhdloiIHCEKcCJtSFl1HY/PX8cLizcTHd6O+88byi/SehIUZLwuTUREjiAFOJE2wFrLByu3c+/sDHaWVHPR6J7cOGEgCe1DvS5NRER8QAFOxM+t3VHKHbPSWbKxgMHdYnj20qMZkRTvdVkiIuJDCnAifqqkqpbH56/npS82ExXWjnvOHcLFo5MIVnepiEibpwAn4mcaGpzZpfd/tIbd5dVcOCqJGycMUHepiEgAUYAT8SPpucXcMWs1K7YUMrxnHC9ckcZRPeK8LktERFqYApyIHyiqqOHheWt5belW4iNDeej8ozh/ZA/NLhURCVAKcCKtWEOD5Y3l2Tw0Zw3FlbX88phkbji1P7GRIV6XJiIiHlKAE2mlVuYUMW3mar7LLmJUcjx3nTOE1G5ajFdERBTgRFqdwvIa/m/eWv771VY6RIXx6C+Gce7w7hij7lIREXEowIm0Eo3dpQ/OWUNpVR1Xjk/h+lP7ER2u7lIREdmbApxIK7B6WzG3vpfOt9lFjE5J4O7JgxnYRd2lIiKyfwpwIh4qq67jkXnreOmLTcRHhvLIz4cxZYS6S0VE5OAU4EQ8YK1lTvoO7no/g52lVVw8Oom/TBio2aUiItIsCnAiLWzr7gpun5XOorX5pHaN4ZlLR2rvUhERf1BbCbkrYOuXUJQN5zzhWSk+C3DGmJ7Ay0BnwALPWWsfN8YkAG8AycBm4OfW2kLj9Bk9DpwJVABXWGu/dl/rcuA296XvtdZOd48fDbwERAAfAtdZa62v3pPIT1FdV88/P9nIUwuzaBdkmDYplcuP6UW74CCvSxMRkYZ6qCmH6hKoLIKqIue6shB2r4ctX8K2b6Ch1jm/02CorYKQcE/K9WULXB3wZ2vt18aYaGCFMeZj4ApggbX2AWPMTcBNwF+BM4B+7mUM8Awwxg18dwBpOEFwhTFmlrW20D3n18BSnAA3EfjIh+9J5Ef5fP0ups1MZ9Oucs4a2pVpk1LpEuvNl15EpE2xFqpLncBVVeyEruoS91gJVBc3uV2y93VNmRPaaiugrurAPyMoBLqNgGN+B0njoOdoiExoqXe4Xz4LcNba7cB293apMSYT6A5MBk50T5sOLMIJcJOBl90WtCXGmDhjTFf33I+ttQUAbgicaIxZBMRYa5e4x18GzkUBTlqRnMIK7v9oDbNXbqdXYiTTrxzNCf07el2WiEjrZC3szoKd6XuC1l7hq3jPpel923Dw1w0Og/AYCIvZc53YEcKiIbQ9hERCaBSERjrHIuIhPA4i4pzrqM6etbQdSIuMgTPGJAMjcFrKOrvhDmAHThcrOOEuu8nTctxjBzues5/j+/v5VwNXAyQlJf2EdyLSPJU19TzzyQb++ckGjIHrT+3HNSf0ITwk2OvSRERal/LdsGkRbFgIGxdBcfY+JxgnVIXFQHisE8BiukHYQOd+RJx7vPHavYRF77luF9bib8vXfB7gjDFRwDvA9dbakqbLI1hrrTHG52PWrLXPAc8BpKWlaYyc+Iy1lvdXbuf+DzPZXlzF2cO6cdMZA+keF+F1aSIi3qkshA3/g/y1ULYTyvL2XBfnABbCYqH38XDsDU4XZUS8E9pCoyBIY4X35dMAZ4wJwQlvr1pr33UP7zTGdLXWbne7SPPc47lAzyZP7+Eey2VPl2vj8UXu8R77OV/EE6u3FXPnrNUs21zI4G4xPH7hCEaneDtGQkTEM7vWw7o5sG4ubPkCbD1goH1Hp0syqhN0GAAJvaH3ic4Ys2AtjtFcvpyFaoDngUxr7SNNHpoFXA484F7PbHL898aY13EmMRS7IW8u8DdjTOM6C6cDN1trC4wxJcaYsThds78E/uGr9yNyIIXlNTzs7l0aFxnK/ecN5edpPQkO0mK8IhJArHVmaWbOgsz3nbFs4MzWPPZ66D8Ruo1USDtCfPlbHA9cBqwyxnzrHrsFJ7i9aYy5CtgC/Nx97EOcJUSycJYRmQrgBrV7gGXueXc3TmgAfseeZUQ+QhMYpAXV1Tfw36+28vC8dZRV13H5uGSuP7U/sRFajFdEAkRdDeQuhzWzIWMWFG8FEwwpx8GYa6D/BIjT2HNfMIG2bFpaWppdvny512WIn1uctYt7PshgzY5SxvVJ5M5zBtO/c7TXZYmI+FZNOeQsc7pEt3zh3K6rguBQ6H0SpJ4DA870fImNtsQYs8Jam7bvcbVjihyGTbvKuW92JvMzd9IjPoJnLhnJxCFdtHepiLRdRVth7RxY+yFs/txZyNYEQZejIO0q6HUMpBzvzPiUFqMAJ9IMxRW1PPG/9bz85WbC2gXz14kDmTo+WcuCiEjbUVsJJdugJNe53rUO1s2Dnaucxzv0h7G/hd4nQI/RznIe4hkFOJGDqG+wvL5sKw/PXUtRZS2/SOvJn07vT6fo1rWgo4jIYasshPUfw5oPnJa1it17P26CIOkYOP1e6H8GdOjrTZ2yXwpwIgewbHMBd8xcTcb2EkanJHDH2akM7qYuAhHxI/V17o4FRc5uBlXFzlpsa2e73aF1ENXFCWgJyRDTw1kkN6a7cx0a6fU7kANQgBPZx/biSu7/cA2zvttG19hwnrx4BGcN7apxbiLiDWv32WC9cO8tpRovlYVQUQCVBU5rWkUh1JTu/zU79Idxf4CBk5ylPbRQrt9RgBNxVdfV8/znm/jHgizqreWPJ/flmhP7EBmqr4mIHGHWQvkuZ5zZrrXOore7NzhBrabcGY9WW+Hcri45xF6fZs+WUpGJENnBCWgRCe6enu72U+Gxzs4Gsd2dxXPFr+lfJhFg0do87no/g027yjk9tTPTJqXSM0FdByJyhFgLBRud7aQ2LoIti50Ws0YhkZDQxwlhMd2c+yGRThdm4z6fjRurN1437vmpraYCkgKcBLTsggru/iCDjzN2ktKhPS9NHcWJAzp5XZaI+LuGemes2bavIXspbFjkLHILENsTBpwFXYZAh37OdlIx3RXC5LAowElAqqqt59lPNvDMog0EGcNfJg7gqmNTCGunZUFE5EeoqYBNn8LmzyD3a9j+HdSWO4+FxTo7E4z/I/Q52em+1Jha+YkU4CSgWGuZl7GTez7IIKewkrOO6sptZw2ia2yE16WJiL8p3ALr5zmbtW/+zNmRoF04dBkKIy6F7iOdCQKJfdW6JkecApwEjA35Zdz1fgafrsunf+coXvv1GMb16eB1WSLSmtXXOrM/i7ZAXibkr9lzXZLrnJPQG46eCv1Ph17joV2YpyVLYFCAkzavuLKWJ/+3npe+2Ex4u2Bun5TKZcf0IiRY/yMWEaB0B2z7xu36/NbZhaBxyY6asr3PbRfujFvrNR66DYd+E7TArXhCAU7arLr6Bv771VYenb+ewooaLji6BzdOGEjHaP3vWCSgFW6GrAXObNCc5VC6zTlugqDjQIhPhq7D9sz4jIh3ZoY2PhaksbLiPQU4aZMWrs3jvtmZZOWVMbZ3AredlcqQ7tpFQSQgVRTA1iXOEh4bFjjLeYAzGzT5WHes2ghn7Fpoe29rFWkmBThpUzbvKufuDzL435o8khMj+edlR3N6amftoiASCKx1ujyLcyFnGWQvgeyvnMVywVlXLfk4GHMN9DkFEvtoNqj4LQU4aRMqaup4euEGnvt0IyHBhlvOHMgV41IIbadxbiJtQkO9M5GgOGfPpWirM16tPN/ZOqp8F9RX73lORDz0HAPDLnKue6RpgoG0GQpw4testcxJ38E9H2SwrbiKKSO6c/MZA+kUE+51aSLyU9TXOmupbVkMW76ArV86+302FdXZGZsW3dXp/oxMhPYdIaqT0yWa2E/Ld0ibpQAnfuvb7CIe+CiTJRsLGNglmscuHMHolASvyxKR5rIWdqyEnRnORIKSJpdd65y9QMEJYqnnOi1ocb0gtodzUWuaBDAFOPE7G/PLeHjeWj5ctYMOUaHcM3kwF41Oop2WBRFp/Rp3LFj3Eaybt2cGKDizPmO6Q0xXp8uz1zjnEqXt7UT2pQAnfiOvtIrH56/n9WXZhLUL4vpT+/Gr43oTFaY/xiKtVukOZ321bV9D7gqnO7SuytmAvc/J0H+iE9Ziujkbt4tIs+hfPmn1yqvr+NdnG3nu043U1DVw6Zgkfn9yP63nJuI1a6GyEEq3O5eS7U5ga+wO3bFqz24FJhg6pcLRVzihrdc4dYGK/AQKcNJq1dU38NaKHB75eB35pdWcObQLf5kwkOQOWqdJxGfqaqBgA+SvdWZ91pQ7Y9FqK53uz5pSKMtzQ9vOvWd9NopIcFrUko6B7kc766x1OUotbCJHkAKctDrWWhaty+f+DzNZt7OMo3vF8+ylR3N0r3ivSxPxf5VFzkK2ZXlQngdlO6Es31mWY9daKNgEtn7v54REQkiEcx3a3hmTlnQMRHeBqC4Q3Rmiuzlj16K6QIhmgYv4mgKctCprdpRw3+xMPlu/i+TESJ69dCQTBnfRQrwiP0ZFgTP2bPt3ey6Fm394XlisE746DXJme3YcAB36O5u0h0ZpKQ6RVkgBTlqFvNIqHpm3jjeXZxMdHsIdZ6dyyZheWohX5HCUbHMmCTRe8jP3PBafAl2Hw8jLnYAW1QWiOkL7TmoxE/FDCnDiqcqaep7/fCNPL9pAbX0DU8en8IeT+xIXGep1aSKth7VQXQoVu5xWtfJdUJIDRdlQnL3nunS7c35oNCSNgaHnQ8/RzviziDhP34KIHFkKcOKJ+gbLu1/n8Pd569hRUsWEwZ25+YxBmqAggam6FPLWOGPQSrbvmdXZOFGgYhfU1/zweUEhexa17XMydB7szO7sPBSC9de7SFumb7i0uM/W53Pf7EzW7ChlWM84/nHxCEYlawcFaYMaGqB4q7NnZ3WZs9F6dalzXbHbmemZl+E83lREgrM9VHQXZ+mN9h3dbaI6QGQH53ZMN2crKY1PEwlICnDSYjK3l/DAR2v4ZF0+PRMi+MdFI5h0VFdNUJC2oaYCspdAzgqnJS1/DezKgrrK/Z8fFOJMFOgx2hmX1inVGZsW011j0kTkkBTgxOe2F1fy93nreOfrHGLCQ7jtrEFcdkwvwtoFe12ayI9jrbObwM4M2LgQNi6C7KV7ujljk6Bjf0g+3gll8ckQHuOMTQuLcmZ2hkSq9UxEfjQFOPGZkqpanlm0gRc+34QFrj6uN787sS+xkSFelyZycNWlkJcJO1c7l7wMZ920mnKn+7OmDGzDnvO7DIUxv4HeJ0LPsU5IExHxIQU4OeJq6hp4dekWnliwnsKKWqaM6M6fT+9Pj3itwi4eq6lwJwbs2DNJoDzfmdVZnu9cyvKdGZ6NQqOhc6oT0kLbO61noe2dkBbXC1KOd8amiYi0IAU4OWKstcxJ38GDc9aweXcF4/smcvMZgxjSPdbr0iQQNNQ7AaxxT86irc5WUE2vq4p/+LzgUGeSQPsOznXHgZDYBzoPccalxSWBxmmKSCujACdHxIothfztw0xWbCmkf+coXpw6ihP7d9QEBTlyyvKdrszS7c4G6SXb9lzKdjqXpt2a4Iwzi0tyWsp6jnFmbjbO7ozu5mwBFR6ngCYifkcBTn6SVTnFPL5gHfMz8+gYHcYD5w3l/KN70C5Yg7PlJ2iod5bYyF4C2V/B1iVQuGnvc8LjnBmb0V2gyxAnmEV1dgNaVye4te+gcCYibZICnPwoTYNbbEQI/+/0/kwdn0L7MP2RkkOwFqpLnEkBZe5m6sXZULjF2aezcLPT3dlQ65wf2QGSxkLaVOg6DGJ7OgEtVGMqRSRw6V9bOSzpucU8Nn898zN3fh/cLh+XTHS4ZpaKq3QnbP7MWVajfJcT1qpLnUtVibOrQF3VD58XEe8st9FlKAw621l+o+cYZ0N1taKJiOxFAU6aJT23mMcXrOfjjJ3EhLfjz6f15/LxycQouAWuupo9Y88KNzubp2/+DHatcx4PjXJaysKinUtUJ2dGZ/tEp6szqrNzrH0niO0O4ZrsIiLSXApwclCrtxXz+Pz1zHOD259O688VCm5tW0O9M1GgKNuZLNAY0srynOU3yvKgbIezFVRTIe2h1zEw/BJIOQ66DNN+nCIiPqK/XWW/svJKeeTjdXy4agfR4e24/tR+TB2fQmyEgpvfq6t2gllRtjPWrDi7ye2tzqzOhrq9nxMcClFdnBaz+GRIGtNk0kAX53anQRCsPx8iIi1BAU72klNYwWPz1/Pu1zlEhATzx5P7ctVxvRXc/E1ZHmxfCTtWOt2bjWujlW77YcsZxp212dPZlzMuybkdmwSxPbTUhohIK6QAJwDkl1bz1MIsXl26BWMMU8en8LsT+5AYFeZ1adKovs4JX+X5zkSAqsbJAe51VbEz/mz7SqeLs1FkB4jp6qyB1uNoZ/2z2O7ObM64JGcpjnah3r0vERE5bApwAa6ipo5/fbqJ5z7dQFVdAxcc3YM/ntKPbnERXpcWmBoanF0Dvt+Dc7WzHlrZTqgsPPhz20VAQoqzH2fXo5zZnF2GOrM7RUSkTVGAC1B19Q28vSKHRz5eR15pNRMHd+HGiQPo01GbcB9R9bVuS1mxe12y57qy0N2Tc4fTYla6A4pzobbcfbJxAlnHQZB8rLPNU2Tinm2fwuP2zPAMi9b4MxGRAKIAF2CstSzIzOPBOWtYn1fGyKQ4nr5kJGnJCV6X5t92b4AN/4OsBbA7a09Qq6s8+POCw/aeBND3VGcvzs5DoNNAZ9N0ERGRfSjABQhrLQvX5vHY/PWszCkmOTGSZy4ZycQhXbRfaXPVVDhjzyp2u2PRdkPOMsiav2ebp/hk6DrcWdMsPAbCGq+jISzGve1eh8c53Zv6/YuIyGFSgGvjrLUsWpfPY/PX8112ET3iI3jwZ0M5b2QPQrRf6R4NDVBZ4Iw1K93ubuu0CQo27dneqabsh88LiYTk42Ds76DvKZDYp6UrFxGRAKQA10bVN1jmrt7Bc59u5NvsIrrHRXD/eUP52cgehLYLkODW0ABVRU1azPLdgLbTHXO2c+9Fam393s8PDoP4XhCf4oxBi+7ijEFrvEQkOI+300xdERFpWQpwbUx5dR1vLs/mhcWbyC6oJCkhkvumDOGCo3v6d3Crr4Mady/NqiJnyYzKIjegFbjhLA/K86As311qY/cPQxmACXImAjRu59RlyN5bO0V1dpbXiO4GQX78OxMRkTZLAa6N2LyrnP8u28p/l26lpKqOo3vFc+uZgzgttQvBQa10jJW1TrdkRYGzG0Dh5r27LCt2QXWZc87+Nj9vKiTSDWXuTgE9Rznrn0UmOjM2G1vNors45wUF+/79iYiI+IgCnB+rqq1nTvoOXl+2lSUbCwgyMHFIF351XG9GJnmw9ldDg7NcRmWhc6kodLsnd+zptizLc1rGGs/Zd8smE+ys/h+fDAm9ISzK2RQ9LNq5bhz8Hx4LEY3X8c5jmgwgIiIBQgHOz9TWN7BscwFz0ncw45tcSqrqSEqI5MYJA/jZyB50iQ0/sj+wpsIZ1P/9VkzbnVBWUeAGsQLndmWB06WJ3f/rhMXs2Tez0yBn/FhE/J5LbHcntMX21HpmIiIih6AA5wdKq2r5ZF0+8zN2snBtPsWVtYS2C+KMIV34xaiejE1JJOhA3aT1de6aZMV7LyJbXepcasrcbspyZzxZeeMyGbucYHagmZeRiU7wikxwQldkwg9DWUScO6asC4RG+vJXJCIiElAU4Fqpkqpa5mfsZPbK7Xy2fhc19Q3ER4Zw6qDOnJbameP6xNO+djcUb4LMz5wV/Eu2Od2U5fnuQP48J4QdqFWskQlyuydj94wV69Bvz/ix6G5Oy1lMN2fB2fCYFvkdiIiIyP4pwLUilTX1zF29g/nfZpGdtZqudicjI3bz227l9I6sJJ4STH4BfOS2ju07wzIkcs9MysQ+0OsYaN/JaQ1ruoBsWMye7ZdCoyAkQuPHRERE/IgCnJeshZJcirKWsmbFItj2DcfZzZxrSqFxGFg9UBYPtqMzq7JDX4gc49yO6QoxPZzxY7E9nMH9CmIiIiJtnt8HOGPMROBxIBj4t7X2AY9LOrjaKtiwAFbPoDZrISGV+cQBR9tgtoX1pi7pTBp6pRKUmOIM6o9Pdro2RURERFx+HeCMMcHAU8BpQA6wzBgzy1qb4W1ljoqaOvIKiti9K5/aLUuJ2/QhyQWfEt5QSTFR/K9+GBlmEp0GjeP0k0+hV+dEr0sWERERP+DXAQ4YDWRZazcCGGNeByYDngW4bx6ZQmLZWiLry4imgmRTS7L7WIGNYl7weNITTqS4yzgGdU/g9yN7EBuhZTNERESk+fw9wHUHspvczwHG7HuSMeZq4GqApKQknxZUGZpAfmRfCIslKDKekKh4IqITiOjSn8TBJ3FOWDjn+LQCERERaev8PcA1i7X2OeA5gLS0tEOsqfHTjPv98758eRERERH8fafuXKBnk/s93GMiIiIibZa/B7hlQD9jTIoxJhS4EJjlcU0iIiIiPuXXXajW2jpjzO+BuTjLiLxgrV3tcVkiIiIiPuXXAQ7AWvsh8KHXdYiIiIi0FH/vQhUREREJOApwIiIiIn5GAU5ERETEzyjAiYiIiPgZBTgRERERP6MAJyIiIuJnFOBERERE/IwCnIiIiIifUYATERER8TPGWut1DS3KGJMPbPHxj+kA7PLxz5DDp8+l9dJn0zrpc2m99Nm0Tr74XHpZazvuezDgAlxLMMYst9ameV2H7E2fS+ulz6Z10ufSeumzaZ1a8nNRF6qIiIiIn1GAExEREfEzCnC+8ZzXBch+6XNpvfTZtE76XFovfTatU4t9LhoDJyIiIuJn1AInIiIi4mcU4I4gY8xEY8xaY0yWMeYmr+sJZMaYnsaYhcaYDGPMamPMde7xBGPMx8aY9e51vNe1BiJjTLAx5htjzAfu/RRjzFL3u/OGMSbU6xoDkTEmzhjztjFmjTEm0xhzjL4z3jPG3OD+PZZujPmvMSZc3xlvGGNeMMbkGWPSmxzb73fEOJ5wP6OVxpiRR7IWBbgjxBgTDDwFnAGkAhcZY1K9rSqg1QF/ttamAmOBa93P4yZggbW2H7DAvS8t7zogs8n9B4FHrbV9gULgKk+qkseBOdbagcAwnM9I3xkPGWO6A38E0qy1Q4Bg4EL0nfHKS8DEfY4d6DtyBtDPvVwNPHMkC1GAO3JGA1nW2o3W2hrgdWCyxzUFLGvtdmvt1+7tUpx/iLrjfCbT3dOmA+d6UmAAM8b0AM4C/u3eN8DJwNvuKfpcPGCMiQWOB54HsNbWWGuL0HemNWgHRBhj2gGRwHb0nfGEtfZToGCfwwf6jkwGXraOJUCcMabrkapFAe7I6Q5kN7mf4x4TjxljkoERwFKgs7V2u/vQDqCzV3UFsMeAvwAN7v1EoMhaW+fe13fHGylAPvCi2739b2NMe/Sd8ZS1Nhd4GNiKE9yKgRXoO9OaHOg74tNcoAAnbZoxJgp4B7jeWlvS9DHrTMHWNOwWZIyZBORZa1d4XYv8QDtgJPCMtXYEUM4+3aX6zrQ8dzzVZJyA3Q1ozw+78KSVaMnviALckZML9Gxyv4d7TDxijAnBCW+vWmvfdQ/vbGzCdq/zvKovQI0HzjHGbMYZZnAyzrirOLd7CPTd8UoOkGOtXerefxsn0Ok7461TgU3W2nxrbS3wLs73SN+Z1uNA3xGf5gIFuCNnGdDPnRkUijPIdJbHNQUsd1zV80CmtfaRJg/NAi53b18OzGzp2gKZtfZma20Pa20yznfkf9baS4CFwPnuafpcPGCt3QFkG2MGuIdOATLQd8ZrW4GxxphI9++1xs9F35nW40DfkVnAL93ZqGOB4iZdrT+ZFvI9gowxZ+KM7wkGXrDW3udtRYHLGHMs8Bmwij1jrW7BGQf3JpAEbAF+bq3dd0CqtABjzInA/7PWTjLG9MZpkUsAvgEutdZWe1heQDLGDMeZXBIKbASm4vxHX98ZDxlj7gJ+gTO7/hvgVzhjqfSdaWHGmP8CJwIdgJ3AHcAM9vMdcQP3kzhd3hXAVGvt8iNWiwKciIiIiH9RF6qIiIiIn1GAExEREfEzCnAiIiIifkYBTkRERMTPKMCJiIiI+BkFOBGRJowxycaY9MM4/wpjTLdmnPPkT69ORMShACci8tNcgbPFkYhIi1GAExH5oXbGmFeNMZnGmLfdVfBvN8YsM8akG2Oec1dXPx9IA141xnxrjIkwxowyxnxhjPnOGPOVMSbafc1uxpg5xpj1xpiHPHxvItIGKMCJiPzQAOBpa+0goAT4HfCktXaUtXYIEAFMsta+DSwHLrHWDgfqgTeA66y1w3D2sax0X3M4zmr6Q4FfGGOa7pEoInJYFOBERH4o21q72L39CnAscJIxZqkxZhVwMjB4P88bAGy31i4DsNaWWGvr3McWWGuLrbVVOHtZ9vLtWxCRtqyd1wWIiLRC++4xaIGngTRrbbYx5k4g/DBfs+k+lfXo718R+QnUAici8kNJxphj3NsXA5+7t3cZY6KA85ucWwo0jnNbC3Q1xowCMMZEG2MU1ETkiNNfLCIiP7QWuNYY8wJOd+czQDyQDuwAljU59yXgWWNMJXAMzji3fxhjInDGv53agnWLSIAw1u7bUyAiIiIirZm6UEVERET8jAKciIiIiJ9RgBMRERHxMwpwIiIiIn5GAU5ERETEzyjAiYiIiPgZBTgRERERP6MAJyIiIuJn/j8dPlmxMz/l7AAAAABJRU5ErkJggg==\n",
       "text/plain": [
        "<Figure size 720x432 with 1 Axes>"
       ]

--- a/scripting/obp_run.py
+++ b/scripting/obp_run.py
@@ -40,18 +40,16 @@ if __name__ == "__main__":
 
     logging.info("Building dataset")
     dataset_spec_path = os.path.join(params.experiment_dir, "dataset_spec.yaml")
-    dataset = utils.load_obj_from_spec(dataset_spec_path)
+    dataset, _ = utils.load_obj_from_spec(dataset_spec_path, "dataset")
 
     logging.info("Building policies")
     policy_spec_path = os.path.join(params.experiment_dir, "policy_spec.yaml")
-    policies = utils.load_obj_from_spec(policy_spec_path)
+    policies = utils.load_obj_from_spec(policy_spec_path, "policy")
 
     if os.path.exists(os.path.join(params.experiment_dir, "estimator_spec.yaml")):
         logging.info("Building estimators")
         estimator_spec_path = os.path.join(params.experiment_dir, "estimator_spec.yaml")
-        estimator, estimator_dict = utils.load_obj_from_spec(
-            estimator_spec_path, return_dict=True
-        )
+        estimator, _ = utils.load_obj_from_spec(estimator_spec_path, "estimator")
 
     if isinstance(dataset, DeezerDataset):
         experiment = DeezerExperiment(dataset, policies)


### PR DESCRIPTION
Changes in this pr:
- `type` no longer has to be specified in yaml files
- random baseline for deezer dataset is now generated using a `Random` policy rather than the old way of not providing a policy to the `obtain_batch_bandit_feedback` method. This makes it easier to tweak the other parameters of `obtain_batch_bandit_feedback` in the `policy_spec.yaml` file.
- minor changes to `utils` to remove unused functionality and allow separating out additional `meta` settings (see notebook)
- updated [Experiments 2](https://github.com/daturkel/sd_bandits/blob/8b0307c64c4d49a31fb2a3d26b1af6f61f5508a2/notebooks/Experiments%202%20-%20Scripting%20Experiments.ipynb) notebook to show how it works now 